### PR TITLE
Fix problem with pickling file instances

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -92,11 +92,11 @@ PartialType = type(partial(int,base=2))
 SuperType = type(super(Exception, TypeError()))
 ItemGetterType = type(itemgetter(0))
 AttrGetterType = type(attrgetter('__repr__'))
-FileType = open(os.devnull, 'rb', buffering=0)
-TextWrapperType = open(os.devnull, 'r', buffering=-1)
-BufferedRandomType = open(os.devnull, 'r+b', buffering=-1)
-BufferedReaderType = open(os.devnull, 'rb', buffering=-1)
-BufferedWriterType = open(os.devnull, 'wb', buffering=-1)
+FileType = type(open(os.devnull, 'rb', buffering=0))
+TextWrapperType = type(open(os.devnull, 'r', buffering=-1))
+BufferedRandomType = type(open(os.devnull, 'r+b', buffering=-1))
+BufferedReaderType = type(open(os.devnull, 'rb', buffering=-1))
+BufferedWriterType = type(open(os.devnull, 'wb', buffering=-1))
 try:
     from cStringIO import StringIO, InputType, OutputType
 except ImportError:


### PR DESCRIPTION
I was trying to pickle files earlier and I think I've found a bug:

``` pytb
Traceback (most recent call last):
  File "example.py", line 2, in <module>
    dill.dumps(open(__file__))
  File "/home/matthew/Programming/C++/Python/eggs/dill/dill.py", line 135, in dumps
    dump(obj, file, protocol, byref)
  File "/home/matthew/Programming/C++/Python/eggs/dill/dill.py", line 128, in dump
    pik.dump(obj)
  File "/usr/lib/python3.3/pickle.py", line 235, in dump
    self.save(obj)
  File "/usr/lib/python3.3/pickle.py", line 317, in save
    rv = reduce(self.proto)
TypeError: cannot serialize '_io.TextIOWrapper' object
```

It can be fixed by adding type for the file type definitions.
