### PR TITLE
Fix pickling of partials when there are no kwargs

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -310,6 +310,10 @@ def _create_function(fcode, fglobals, fname=None, fdefaults=None, \
     return func
 
 def _create_ftype(ftypeobj, func, args, kwds):
+    if kwds is None:
+        kwds = {}
+    if args is None:
+        args = ()
     return ftypeobj(func, *args, **kwds)
 
 def _create_lock(locked, *args):

--- a/tests/test_functors.py
+++ b/tests/test_functors.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2008-2014 California Institute of Technology.
+# License: 3-clause BSD.  The full license text is available at:
+#  - http://trac.mystic.cacr.caltech.edu/project/pathos/browser/dill/LICENSE
+
+import functools
+import dill
+
+def f(a, b, c):  # without keywords
+    pass
+
+def g(a, b, c=2):  # with keywords
+    pass
+
+def h(a=1, b=2, c=3):  # without args
+    pass
+
+fp = functools.partial(f, 1, 2)
+gp = functools.partial(g, 1, c=2)
+hp = functools.partial(h, 1, c=2)
+bp = functools.partial(int, base=2)
+
+assert dill.pickles(fp, safe=True)
+assert dill.pickles(gp, safe=True)
+assert dill.pickles(hp, safe=True)
+assert dill.pickles(bp, safe=True)


### PR DESCRIPTION
Fixes errors in the form:

``` pycon
Python 3.4.1 (default, May 19 2014, 17:23:49) 
[GCC 4.9.0 20140507 (prerelease)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import functools, dill
>>> def f(a, b, c): pass
... 
>>> g = functools.partial(f, 1, 2)
>>> dill.copy(g)
(<class 'TypeError'>, TypeError('type object argument after ** must be a mapping, not NoneType',), <traceback object at 0x7f9715a66088>)
<function _create_ftype at 0x7f97120272f0> (<class 'functools.partial'>, <function f at 0x7f9715a621e0>, (1, 2), None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/matthew/GitHub/dill/dill/dill.py", line 127, in copy
    return loads(dumps(obj, *args, **kwds))
  File "/home/matthew/GitHub/dill/dill/dill.py", line 160, in loads
    return load(file)
  File "/home/matthew/GitHub/dill/dill/dill.py", line 150, in load
    obj = pik.load()
  File "/usr/lib/python3.4/pickle.py", line 1036, in load
    dispatch[key[0]](self)
  File "/usr/lib/python3.4/pickle.py", line 1382, in load_reduce
    value = func(*args)
  File "/home/matthew/GitHub/dill/dill/dill.py", line 313, in _create_ftype
    return ftypeobj(func, *args, **kwds)
TypeError: type object argument after ** must be a mapping, not NoneType
>>>
```

This occurs when there are no kwargs. Tested with python 2.7 and 3.4.
