### PR TITLE
Add support for properties

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -1000,6 +1000,12 @@ def save_type(pickler, obj):
         StockPickler.save_global(pickler, obj)
     return
 
+@register(property)
+def save_property(pickler, obj):
+    log.info("Pr: %s" % obj)
+    pickler.save_reduce(property, (obj.fget, obj.fset, obj.fdel, obj.__doc__),
+                        obj=obj)
+
 # quick sanity checking
 def pickles(obj,exact=False,safe=False,**kwds):
     """quick check if object pickles with dill"""

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2008-2015 California Institute of Technology.
+# License: 3-clause BSD.  The full license text is available at:
+#  - http://trac.mystic.cacr.caltech.edu/project/pathos/browser/dill/LICENSE
+
+import dill
+
+
+class Foo(object):
+    def __init__(self):
+        self._data = 1
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, x):
+        self._data = x
+
+FooS = dill.copy(Foo)
+
+assert FooS.data.fget is not None
+assert FooS.data.fset is not None
+assert FooS.data.fdel is None
+
+try:
+    res = FooS().data
+except Exception as e:
+    raise AssertionError(str(e))
+else:
+    assert res == 1
+
+try:
+    f = FooS()
+    f.data = 1024
+    res = f.data
+except Exception as e:
+    raise AssertionError(str(e))
+else:
+    assert res == 1024


### PR DESCRIPTION
Fix for #81. Adds a `save_property` function that converts properties into getter, setter, deleter and doc, which are the arguments to the property constructer. Adds the log entry `Pr: <property object at 0xXXXXXXXXXXXX>` when pickling a property. A test (based on the issue) is in `tests/test_properties.py`.