### PR TITLE
Small fix to allow pickling functions in pypy

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -698,42 +698,6 @@ def save_code(pickler, obj):
     log.info("# Co")
     return
 
-@register(FunctionType)
-def save_function(pickler, obj):
-    if not _locate_function(obj): #, pickler._session):
-        log.info("F1: %s" % obj)
-        if getattr(pickler, '_recurse', False):
-            # recurse to get all globals referred to by obj
-            from .detect import globalvars
-            globs = globalvars(obj, recurse=True, builtin=True)
-            # remove objects that have already been serialized
-           #stacktypes = (ClassType, TypeType, FunctionType)
-           #for key,value in list(globs.items()):
-           #    if isinstance(value, stacktypes) and value in stack:
-           #        del globs[key]
-            # ABORT: if self-references, use _recurse=False
-            if obj in globs.values(): # or obj in stack:
-                globs = obj.__globals__ if PY3 else obj.func_globals
-        else:
-            globs = obj.__globals__ if PY3 else obj.func_globals
-       #stack.add(obj)
-        if PY3:
-            pickler.save_reduce(_create_function, (obj.__code__,
-                                globs, obj.__name__,
-                                obj.__defaults__, obj.__closure__,
-                                obj.__dict__), obj=obj)
-        else:
-            pickler.save_reduce(_create_function, (obj.func_code,
-                                globs, obj.func_name,
-                                obj.func_defaults, obj.func_closure,
-                                obj.__dict__), obj=obj)
-        log.info("# F1")
-    else:
-        log.info("F2: %s" % obj)
-        StockPickler.save_global(pickler, obj) #NOTE: also takes name=...
-        log.info("# F2")
-    return
-
 @register(dict)
 def save_module_dict(pickler, obj):
     if is_dill(pickler) and obj == pickler._main.__dict__ and not pickler._session:
@@ -1186,6 +1150,42 @@ def save_classmethod(pickler, obj):
             orig_func = getattr(orig_func, im_func) # Unbind
     pickler.save_reduce(type(obj), (orig_func,), obj=obj)
     log.info("# Cm")
+
+@register(FunctionType)
+def save_function(pickler, obj):
+    if not _locate_function(obj): #, pickler._session):
+        log.info("F1: %s" % obj)
+        if getattr(pickler, '_recurse', False):
+            # recurse to get all globals referred to by obj
+            from .detect import globalvars
+            globs = globalvars(obj, recurse=True, builtin=True)
+            # remove objects that have already been serialized
+           #stacktypes = (ClassType, TypeType, FunctionType)
+           #for key,value in list(globs.items()):
+           #    if isinstance(value, stacktypes) and value in stack:
+           #        del globs[key]
+            # ABORT: if self-references, use _recurse=False
+            if obj in globs.values(): # or obj in stack:
+                globs = obj.__globals__ if PY3 else obj.func_globals
+        else:
+            globs = obj.__globals__ if PY3 else obj.func_globals
+       #stack.add(obj)
+        if PY3:
+            pickler.save_reduce(_create_function, (obj.__code__,
+                                globs, obj.__name__,
+                                obj.__defaults__, obj.__closure__,
+                                obj.__dict__), obj=obj)
+        else:
+            pickler.save_reduce(_create_function, (obj.func_code,
+                                globs, obj.func_name,
+                                obj.func_defaults, obj.func_closure,
+                                obj.__dict__), obj=obj)
+        log.info("# F1")
+    else:
+        log.info("F2: %s" % obj)
+        StockPickler.save_global(pickler, obj) #NOTE: also takes name=...
+        log.info("# F2")
+    return
 
 # quick sanity checking
 def pickles(obj,exact=False,safe=False,**kwds):


### PR DESCRIPTION
Hi, thanks for a great package!

Pickling functions with `dill` currently doesn't work with `pypy`:
```
Python 3.2.5 (b2091e973da69152b3f928bfaabd5d2347e6df46, Sep 23 2015, 09:21:00)
[PyPy 2.4.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.72)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> import dill
>>>> def cool(x):
....     return x
....
>>>> s = dill.dumps(cool)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "dill/dill.py", line 197, in dumps
    dump(obj, file, protocol, byref, fmode, recurse)#, strictio)
  File "dill/dill.py", line 190, in dump
    pik.dump(obj)
  File "/usr/local/Cellar/pypy3/2.4.0/libexec/lib-python/3/pickle.py", line 237, in dump
    self.save(obj)
  File "/usr/local/Cellar/pypy3/2.4.0/libexec/lib-python/3/pickle.py", line 299, in save
    f(self, obj) # Call unbound method with explicit self
  File "dill/dill.py", line 944, in save_wrapper_descriptor
    pickler.save_reduce(_getattr, (obj.__objclass__, obj.__name__,
AttributeError: 'function' object has no attribute '__objclass__'
```
The reason is that, in `dill.py`, `MethodDescriptorType` and `WrapperDescriptorType` are defined as `WrapperDescriptorType = type(type.__repr__)` and `MethodDescriptorType = type(type.__dict__['mro'])`. But `type(type.__repr__)` and `type(type.__dict__['mro'])` return `FunctionType` in PyPy. Then subsequently, `MethodDescriptorType` and `WrapperDescriptorType` are registered _after_ `FunctionType`, with the result that these registrations overwrite the registration for `FunctionType`, and make functions unpickleable.

As a quick minimal fix, I moved the registration of `FunctionType` after the registration of these other types. Now pickling functions works fine under PyPy:

```
Python 3.2.5 (b2091e973da69152b3f928bfaabd5d2347e6df46, Sep 23 2015, 09:21:00)
[PyPy 2.4.0 with GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.72)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>> import dill
>>>> def cool(x):
....     return x
....
>>>> s = dill.dumps(cool)
>>>> f = dill.loads(s)
>>>> f(3)
3
```

I'm not sure if method descriptors and wrapper descriptors end up pickled correctly in PyPy given this fix, but surely pickling functions is a more frequent use case than pickling the other types.