### PR TITLE
Only flush if file is open

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -881,10 +881,10 @@ def save_attrgetter(pickler, obj):
     return
 
 def _save_file(pickler, obj, open_):
-    obj.flush()
     if obj.closed:
         position = None
     else:
+        obj.flush()
         if obj in (sys.__stdout__, sys.__stderr__, sys.__stdin__):
             position = -1
         else:


### PR DESCRIPTION
Fix for #143. Move `obj.flush()` inside the `if obj.closed` checking.