### PR TITLE
Fix for CellTypes when ctypes is missing

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -665,6 +665,10 @@ if HAS_CTYPES and IS_PYPY:
     except AttributeError:
         IS_PYPY = False
 
+else:
+    def _create_cell(contents):
+        return (lambda x: lambda: x)(contents).func_closure[0]
+
 def _create_weakref(obj, *args):
     from weakref import ref
     if obj is None: # it's dead
@@ -1036,13 +1040,12 @@ else:
         log.info("# Wr")
         return
 
-if HAS_CTYPES and IS_PYPY:
-    @register(CellType)
-    def save_cell(pickler, obj):
-        log.info("Ce: %s" % obj)
-        pickler.save_reduce(_create_cell, (obj.cell_contents,), obj=obj)
-        log.info("# Ce")
-        return
+@register(CellType)
+def save_cell(pickler, obj):
+    log.info("Ce: %s" % obj)
+    pickler.save_reduce(_create_cell, (obj.cell_contents,), obj=obj)
+    log.info("# Ce")
+    return
 
 # The following function is based on 'saveDictProxy' from spickle
 # Copyright (c) 2011 by science+computing ag

--- a/dill/dill.py
+++ b/dill/dill.py
@@ -133,11 +133,15 @@ else:
     def ndarraysubclassinstance(obj): return False
     def numpyufunc(obj): return False
 
-# make sure to add these 'hand-built' types to _typemap
 if PY3:
-    CellType = type((lambda x: lambda y: x)(0).__closure__[0])
+    def _create_cell(contents):
+        return (lambda: contents).__closure__[0]
 else:
-    CellType = type((lambda x: lambda y: x)(0).func_closure[0])
+    def _create_cell(contents):
+        return (lambda: contents).func_closure[0]
+
+# make sure to add these 'hand-built' types to _typemap
+CellType = type(_create_cell(0))
 WrapperDescriptorType = type(type.__repr__)
 MethodDescriptorType = type(type.__dict__['mro'])
 MethodWrapperType = type([].__repr__)
@@ -664,10 +668,6 @@ if HAS_CTYPES and IS_PYPY:
 
     except AttributeError:
         IS_PYPY = False
-
-else:
-    def _create_cell(contents):
-        return (lambda x: lambda: x)(contents).func_closure[0]
 
 def _create_weakref(obj, *args):
     from weakref import ref


### PR DESCRIPTION
Fixes https://github.com/uqfoundation/dill/issues/150 by creating cell objects without the use of ctypes (courtesy of http://nedbatchelder.com/blog/201301/byterun_and_making_cells.html )