### PR TITLE
Fix pickling of __main__ classes with __slots__

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -1214,6 +1214,8 @@ def save_type(pickler, obj):
        #print (_dict)
        #print ("%s\n%s" % (type(obj), obj.__name__))
        #print ("%s\n%s" % (obj.__bases__, obj.__dict__))
+        for name in _dict.get("__slots__", []):
+            del _dict[name]
         pickler.save_reduce(_create_type, (type(obj), obj.__name__,
                                            obj.__bases__, _dict), obj=obj)
         log.info("# %s" % _t)


### PR DESCRIPTION
Passing `__slots__` in the dict to `type` recreates the slots, so the member descriptors are not needed. This removes them from the dict, so that recursion does not occur. Fixes #152. Tested on python 3.5 and 2.7.