### PR TITLE
On Py3, use cPickle Unpickler

### DIFF
--- a/dill/dill.py
+++ b/dill/dill.py
@@ -37,7 +37,7 @@ _use_diff = False
 PY3 = (sys.hexversion >= 0x30000f0)
 if PY3: #XXX: get types from .objtypes ?
     import builtins as __builtin__
-    from pickle import _Pickler as StockPickler, _Unpickler as StockUnpickler
+    from pickle import _Pickler as StockPickler, Unpickler as StockUnpickler
     from _thread import LockType
    #from io import IOBase
     from types import CodeType, FunctionType, MethodType, GeneratorType, \


### PR DESCRIPTION
Pure-Python unpickler, available as `pickle._Unpickler`, uses `struct` to unpack
data, and the latter can also fail with `struct.error`. The default
C unpickler fails with documented and expectable `UnpicklingError`, and
is also faster.

Dill's unpickler seems to be a very thin wrapper around pickle's unpickler, so the change is not grave in any way, just somewhat more convenient for the end user.

-----
I'd like to help set up continuous integration build testing on Travis. What is the canonical way to run and depend on tests in the _tests_ folder? If the files are run sequentially and all asserts pass, the build is considered passing?