### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+sudo: false
+
+matrix:
+    include:
+        - python: '2.7'
+        - python: '3.4'
+        - python: '3.5'
+        - python: '3.6-dev'
+        - python: 'nightly'
+    allow_failures:
+        - python: '3.5'
+        - python: '3.6-dev'
+        - python: 'nightly'
+    fast_finish: true
+
+cache:
+    pip: true
+
+before_install:
+    - set -e  # fail on any error
+
+install:
+    - python setup.py build && python setup.py install
+
+script:
+    - for test in tests/*.py; do echo $test ; python $test > /dev/null ; done


### PR DESCRIPTION
Contrary to other CI attempts, I choose the least invested route that is hopefully very easy to review and merge.

This just runs the test examples on Travis, reporting any failures. When you enable CI for this repo on Travis, as you can see, [the build passes](https://travis-ci.org/kernc/dill/builds/177006898), except for the newer Python versions which you will eventually (hopefully) bring up to speed. :smile:

Python <=2.6 support is not tested. Nobody uses that any more.