### PR TITLE
Initial tox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.tox/
+.cache/
+*.egg-info/
+*.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist =
+    py36
+    py35
+    py34
+    py33
+    py27
+    py26
+    pypy3
+    pypy
+
+[testenv]
+whitelist_externals =
+    bash
+commands =
+    bash -c "failed=0; for file in tests/*.py; do echo $file; \
+             python $file || failed=1; done; exit $failed"


### PR DESCRIPTION
This commit implements initial `tox` support, which eases the process of running the tests with different interpreters locally.

It does not:

- Modify `.travis.yml` file (Travis CI unaltered).
- Modify the style in which tests are run (no `pytest` integration, all tests are run directly with the interpreter).