### PR TITLE
Drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,7 @@ sudo: false
 
 matrix:
     include:
-        - python: '2.5'
-          dist: trusty
-          sudo: false
-        - python: '2.6'
-          dist: trusty
-          sudo: false
         - python: '2.7'
-          dist: trusty
-          sudo: false
-        - python: '3.1'
-          dist: trusty
-          sudo: false
-        - python: '3.2'
-          dist: trusty
-          sudo: false
-        - python: '3.3'
           dist: trusty
           sudo: false
         - python: '3.4'
@@ -44,11 +29,6 @@ matrix:
           dist: trusty
           sudo: false
     allow_failures:
-        - python: '2.5'
-        - python: '2.6'
-        - python: '3.1'
-        - python: '3.2'
-        - python: '3.3'
         - python: 'nightly'
         - python: 'pypy3'
     fast_finish: true

--- a/dill/__diff.py
+++ b/dill/__diff.py
@@ -32,7 +32,7 @@ getrefcount = getattr(sys, 'getrefcount', lambda x:0)
 memo = {}
 id_to_obj = {}
 # types that cannot have changing attributes
-builtins_types = set((str, list, dict, set, frozenset, int))
+builtins_types = {str, list, dict, set, frozenset, int}
 dont_memo = set(id(i) for i in (memo, sys.modules, sys.path_importer_cache,
              os.environ, id_to_obj))
 

--- a/dill/__diff.py
+++ b/dill/__diff.py
@@ -33,8 +33,8 @@ memo = {}
 id_to_obj = {}
 # types that cannot have changing attributes
 builtins_types = {str, list, dict, set, frozenset, int}
-dont_memo = set(id(i) for i in (memo, sys.modules, sys.path_importer_cache,
-             os.environ, id_to_obj))
+dont_memo = {id(i) for i in (memo, sys.modules, sys.path_importer_cache,
+             os.environ, id_to_obj)}
 
 
 def get_attrs(obj):
@@ -95,13 +95,13 @@ def memorise(obj, force=False):
     if g is None:
         attrs_id = None
     else:
-        attrs_id = dict((key,id_(value)) for key, value in g.items())
+        attrs_id = {key: id_(value) for key, value in g.items()}
 
     s = get_seq(obj)
     if s is None:
         seq_id = None
     elif hasattr(s, "items"):
-        seq_id = dict((id_(key),id_(value)) for key, value in s.items())
+        seq_id = {id_(key): id_(value) for key, value in s.items()}
     elif not hasattr(s, "__len__"): #XXX: avoid TypeError from unexpected case
         seq_id = None
     else:
@@ -176,7 +176,7 @@ def whats_changed(obj, seen=None, simple=False, first=True):
     else:
         obj_attrs = memo[obj_id][0]
         obj_get = obj_attrs.get
-        changed = dict((key,None) for key in obj_attrs if key not in attrs)
+        changed = {key: None for key in obj_attrs if key not in attrs}
         for key, o in attrs.items():
             if id_(o) != obj_get(key, None) or chngd(o, seen, True, False):
                 changed[key] = o

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -29,7 +29,7 @@ def _trace(boolean):
     else: log.setLevel(logging.WARN)
     return
 
-stack = dict()  # record of 'recursion-sensitive' pickled objects
+stack = {}  # record of 'recursion-sensitive' pickled objects
 
 import os
 import sys
@@ -563,9 +563,9 @@ if not IS_PYPY:
 else:
     _reverse_typemap['MemberDescriptorType'] = MemberDescriptorType
 if PY3:
-    _typemap = dict((v, k) for k, v in _reverse_typemap.items())
+    _typemap = {v: k for k, v in _reverse_typemap.items()}
 else:
-    _typemap = dict((v, k) for k, v in _reverse_typemap.iteritems())
+    _typemap = {v: k for k, v in _reverse_typemap.iteritems()}
 
 def _unmarshal(string):
     return marshal.loads(string)
@@ -580,8 +580,8 @@ def _create_function(fcode, fglobals, fname=None, fdefaults=None, \
                                       fclosure=None, fdict=None):
     # same as FunctionType, but enable passing __dict__ to new function,
     # __dict__ is the storehouse for attributes added after function creation
-    if fdict is None: fdict = dict()
-    func = FunctionType(fcode, fglobals or dict(), fname, fdefaults, fclosure)
+    if fdict is None: fdict = {}
+    func = FunctionType(fcode, fglobals or {}, fname, fdefaults, fclosure)
     func.__dict__.update(fdict) #XXX: better copy? option to copy?
     return func
 
@@ -1240,8 +1240,8 @@ def save_module(pickler, obj):
         if hasattr(obj, "__file__"):
             names = ["base_prefix", "base_exec_prefix", "exec_prefix",
                      "prefix", "real_prefix"]
-            builtin_mod = any([obj.__file__.startswith(os.path.normpath(getattr(sys, name)))
-                           for name in names if hasattr(sys, name)])
+            builtin_mod = any(obj.__file__.startswith(os.path.normpath(getattr(sys, name)))
+                           for name in names if hasattr(sys, name))
             builtin_mod = builtin_mod or 'site-packages' in obj.__file__
         else:
             builtin_mod = True
@@ -1268,7 +1268,7 @@ def save_type(pickler, obj):
         log.info("T1: %s" % obj)
         pickler.save_reduce(_load_type, (_typemap[obj],), obj=obj)
         log.info("# T1")
-    elif issubclass(obj, tuple) and all([hasattr(obj, attr) for attr in ('_fields','_asdict','_make','_replace')]):
+    elif issubclass(obj, tuple) and all(hasattr(obj, attr) for attr in ('_fields','_asdict','_make','_replace')):
         # special case: namedtuples
         log.info("T6: %s" % obj)
         pickler.save_reduce(_create_namedtuple, (getattr(obj, "__qualname__", obj.__name__), obj._fields, obj.__module__), obj=obj)

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -270,7 +270,7 @@ def dump(obj, file, protocol=None, byref=None, fmode=None, recurse=None):#, stri
     if NumpyArrayType and ndarraysubclassinstance(obj):
         @register(type(obj))
         def save_numpy_array(pickler, obj):
-            log.info("Nu: (%s, %s)" % (obj.shape,obj.dtype))
+            log.info("Nu: ({}, {})".format(obj.shape,obj.dtype))
             npdict = getattr(obj, '__dict__', None)
             f, args, state = obj.__reduce__()
             pickler.save_reduce(_create_array, (f,args,state,npdict), obj=obj)
@@ -367,7 +367,7 @@ def _restore_modules(main_module):
         return
     imports = main_module.__dict__.pop('__dill_imported')
     for module, name in imports:
-        exec("from %s import %s" % (module, name), main_module.__dict__)
+        exec("from {} import {}".format(module, name), main_module.__dict__)
 
 #NOTE: 06/03/15 renamed main_module to main
 def dump_session(filename='/tmp/session.pkl', main=None, byref=False):
@@ -1050,11 +1050,11 @@ def save_builtin_method(pickler, obj):
         if obj.__self__ is __builtin__:
             module = 'builtins' if PY3 else '__builtin__'
             _t = "B1"
-            log.info("%s: %s" % (_t, obj))
+            log.info("{}: {}".format(_t, obj))
         else:
             module = obj.__self__
             _t = "B3"
-            log.info("%s: %s" % (_t, obj))
+            log.info("{}: {}".format(_t, obj))
         if is_dill(pickler):
             _recurse = pickler._recurse
             pickler._recurse = False
@@ -1204,10 +1204,10 @@ def save_weakproxy(pickler, obj):
     refobj = _locate_object(_proxy_helper(obj))
     try:
         _t = "R2"
-        log.info("%s: %s" % (_t, obj))
+        log.info("{}: {}".format(_t, obj))
     except ReferenceError:
         _t = "R3"
-        log.info("%s: %s" % (_t, sys.exc_info()[1]))
+        log.info("{}: {}".format(_t, sys.exc_info()[1]))
    #callable = bool(getattr(refobj, '__call__', None))
     if type(obj) is CallableProxyType: callable = True
     else: callable = False
@@ -1280,7 +1280,7 @@ def save_type(pickler, obj):
             if is_dill(pickler) and not pickler._byref:
                 # thanks to Tom Stepleton pointing out pickler._session unneeded
                 _t = 'T2'
-                log.info("%s: %s" % (_t, obj))
+                log.info("{}: {}".format(_t, obj))
                 _dict = _dict_from_dictproxy(obj.__dict__)
         #   except: # punt to StockPickler (pickle by class reference)
             else:
@@ -1290,7 +1290,7 @@ def save_type(pickler, obj):
                 return
         else:
             _t = 'T3'
-            log.info("%s: %s" % (_t, obj))
+            log.info("{}: {}".format(_t, obj))
             _dict = obj.__dict__
        #print (_dict)
        #print ("%s\n%s" % (type(obj), obj.__name__))
@@ -1438,7 +1438,7 @@ def check(obj, *args, **kwds):
     finally:
         if fail and verbose:
             print("DUMP FAILED")
-    msg = "%s -c import dill; print(dill.loads(%s))" % (python, repr(_obj))
+    msg = "{} -c import dill; print(dill.loads({}))".format(python, repr(_obj))
     msg = "SUCCESS" if not subprocess.call(msg.split(None,2)) else "LOAD FAILED"
     if verbose:
         print(msg)

--- a/dill/detect.py
+++ b/dill/detect.py
@@ -265,8 +265,8 @@ def badobjects(obj, depth=0, exact=False, safe=False):
     if not depth:
         if pickles(obj,exact,safe): return None
         return obj
-    return dict(((attr, badobjects(getattr(obj,attr),depth-1,exact,safe)) \
-           for attr in dir(obj) if not pickles(getattr(obj,attr),exact,safe)))
+    return {attr: badobjects(getattr(obj,attr),depth-1,exact,safe) \
+           for attr in dir(obj) if not pickles(getattr(obj,attr),exact,safe)}
 
 def badtypes(obj, depth=0, exact=False, safe=False):
     """get types for objects that fail to pickle"""
@@ -274,8 +274,8 @@ def badtypes(obj, depth=0, exact=False, safe=False):
     if not depth:
         if pickles(obj,exact,safe): return None
         return type(obj)
-    return dict(((attr, badtypes(getattr(obj,attr),depth-1,exact,safe)) \
-           for attr in dir(obj) if not pickles(getattr(obj,attr),exact,safe)))
+    return {attr: badtypes(getattr(obj,attr),depth-1,exact,safe) \
+           for attr in dir(obj) if not pickles(getattr(obj,attr),exact,safe)}
 
 def errors(obj, depth=0, exact=False, safe=False):
     """get errors for objects that fail to pickle"""
@@ -285,9 +285,9 @@ def errors(obj, depth=0, exact=False, safe=False):
             pik = copy(obj)
             if exact:
                 assert pik == obj, \
-                    "Unpickling produces %s instead of %s" % (pik,obj)
+                    "Unpickling produces {} instead of {}".format(pik,obj)
             assert type(pik) == type(obj), \
-                "Unpickling produces %s instead of %s" % (type(pik),type(obj))
+                "Unpickling produces {} instead of {}".format(type(pik),type(obj))
             return None
         except Exception:
             import sys

--- a/dill/detect.py
+++ b/dill/detect.py
@@ -157,13 +157,13 @@ def freevars(func):
         func = getattr(func, func_code).co_freevars # get freevars
     else:
         return {}
-    return dict((name,c.cell_contents) for (name,c) in zip(func,closures))
+    return {name: c.cell_contents for (name,c) in zip(func,closures)}
 
 # thanks to Davies Liu for recursion of globals
 def nestedglobals(func, recurse=True):
     """get the names of any globals found within func"""
     func = code(func)
-    if func is None: return list()
+    if func is None: return []
     from .temp import capture
     names = set()
     with capture('stdout') as out:
@@ -172,7 +172,7 @@ def nestedglobals(func, recurse=True):
         if '_GLOBAL' in line:
             name = line.split('(')[-1].split(')')[0]
             names.add(name)
-    for co in getattr(func, 'co_consts', tuple()):
+    for co in getattr(func, 'co_consts', ()):
         if co and recurse and iscode(co):
             names.update(nestedglobals(co, recurse=True))
     return list(names)
@@ -236,7 +236,7 @@ def globalvars(func, recurse=True, builtin=False):
     else:
         return {}
     #NOTE: if name not in func_globals, then we skip it...
-    return dict((name,globs[name]) for name in func if name in globs)
+    return {name: globs[name] for name in func if name in globs}
 
 
 def varnames(func):

--- a/dill/objtypes.py
+++ b/dill/objtypes.py
@@ -15,7 +15,7 @@ to load more objects and types, use dill.load_types()
 # non-local import of dill.objects
 from dill import objects
 for _type in objects.keys():
-    exec("%s = type(objects['%s'])" % (_type,_type))
+    exec("{} = type(objects['{}'])".format(_type,_type))
     
 del objects
 try:

--- a/dill/source.py
+++ b/dill/source.py
@@ -83,7 +83,7 @@ def _matchlambda(func, line):
         _, code = getcode(_f).co_code, getcode(func).co_code
         if len(_) != len(code): return False
         #NOTE: should be same code same order, but except for 't' and '\x88'
-        _ = set((i,j) for (i,j) in zip(_,code) if i != j)
+        _ = {(i,j) for (i,j) in zip(_,code) if i != j}
         if len(_) != 1: return False #('t','\x88')
         return True
     # check indentsize
@@ -981,7 +981,7 @@ def importable(obj, alias='', source=None, builtin=True):
             # get source code of objects referred to by obj in global scope
             from .detect import globalvars
             obj = globalvars(obj) #XXX: don't worry about alias? recurse? etc?
-            obj = list(getsource(_obj,name,force=True) for (name,_obj) in obj.items() if not isbuiltin(_obj))
+            obj = [getsource(_obj,name,force=True) for (name,_obj) in obj.items() if not isbuiltin(_obj)]
             obj = '\n'.join(obj) if obj else ''
             # combine all referred-to source (global then enclosing)
             if not obj: return src

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ Requirements
 
 ``dill`` requires:
 
-    - ``python``, **version >= 2.5** or **version >= 3.1**, or ``pypy``
+    - ``python``, **version 2.7** or **version >= 3.4**, or ``pypy``
     - ``pyreadline``, **version >= 1.7.1** (on windows)
 
 Optional requirements:
@@ -250,13 +250,8 @@ setup(name='dill',
                      'Intended Audience :: Science/Research',
                      'License :: OSI Approved :: BSD License',
                      'Programming Language :: Python :: 2',
-                     'Programming Language :: Python :: 2.5',
-                     'Programming Language :: Python :: 2.6',
                      'Programming Language :: Python :: 2.7',
                      'Programming Language :: Python :: 3',
-                     'Programming Language :: Python :: 3.1',
-                     'Programming Language :: Python :: 3.2',
-                     'Programming Language :: Python :: 3.3',
                      'Programming Language :: Python :: 3.4',
                      'Programming Language :: Python :: 3.5',
                      'Programming Language :: Python :: 3.6',
@@ -281,11 +276,6 @@ if has_setuptools:
         setup_code += """
       install_requires = ['pyreadline%s'],
 """ % (pyreadline_version)
-    # verrrry unlikely that this is still relevant
-    elif hex(sys.hexversion) < '0x20500f0':
-        setup_code += """
-      install_requires = ['ctypes%s'],
-""" % (ctypes_version)
 
 # add the scripts, and close 'setup' call
 setup_code += """    

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ The latest released version of ``dill`` is available from:
     >>> print (dill.license())
 
 
-Development Version 
+Development Version
 ===================
 
 You can get the latest development version with all the shiny new features at:
@@ -151,7 +151,7 @@ download the tarball, unzip, and run the installer::
     $ python setup py install
 
 You will be warned of any missing dependencies and/or settings
-after you run the "build" step above. 
+after you run the "build" step above.
 
 Alternately, ``dill`` can be installed with ``pip`` or ``easy_install``::
 
@@ -244,7 +244,7 @@ setup(name='dill',
       platforms = ['Linux', 'Windows', 'Mac'],
       url = 'https://pypi.org/project/dill',
       download_url = 'https://github.com/uqfoundation/dill/releases/download/dill-%s/dill-%s.tar.gz',
-      python_requires='>=2.5, !=3.0.*',
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       classifiers = ['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',
                      'Intended Audience :: Science/Research',

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -22,6 +22,6 @@ if __name__ == '__main__':
 
     for test in tests:
         print('.', end='')
-        os.system('{0} {1}'.format(python, test))
+        os.system('{} {}'.format(python, test))
     print('')
 

--- a/tests/test_classdef.py
+++ b/tests/test_classdef.py
@@ -88,19 +88,16 @@ def test_class_objects():
 def test_none():
     assert dill.pickles(type(None))
 
-if hex(sys.hexversion) >= '0x20600f0':
-    from collections import namedtuple
-    Z = namedtuple("Z", ['a','b'])
-    Zi = Z(0,1)
-    X = namedtuple("Y", ['a','b'])
-    X.__name__ = "X"
-    if hex(sys.hexversion) >= '0x30300f0':
-        X.__qualname__ = "X" #XXX: name must 'match' or fails to pickle
-    Xi = X(0,1)
-    Bad = namedtuple("FakeName", ['a','b'])
-    Badi = Bad(0,1)
-else:
-    Z = Zi = X = Xi = Bad = Badi = None
+from collections import namedtuple
+Z = namedtuple("Z", ['a','b'])
+Zi = Z(0,1)
+X = namedtuple("Y", ['a','b'])
+X.__name__ = "X"
+if hex(sys.hexversion) >= '0x30300f0':
+    X.__qualname__ = "X" #XXX: name must 'match' or fails to pickle
+Xi = X(0,1)
+Bad = namedtuple("FakeName", ['a','b'])
+Badi = Bad(0,1)
 
 # test namedtuple
 def test_namedtuple():

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -66,17 +66,17 @@ def test_globals():
     assert globalvars(f) == dict(a=1, b=2, c=3)
 
     res = globalvars(foo, recurse=True)
-    assert set(res) == set(['squared', 'a'])
+    assert set(res) == {'squared', 'a'}
     res = globalvars(foo, recurse=False)
     assert res == {}
     zap = foo(2)
     res = globalvars(zap, recurse=True)
-    assert set(res) == set(['squared', 'a'])
+    assert set(res) == {'squared', 'a'}
     res = globalvars(zap, recurse=False)
-    assert set(res) == set(['squared'])
+    assert set(res) == {'squared'}
     del zap
     res = globalvars(squared)
-    assert set(res) == set(['a'])
+    assert set(res) == {'a'}
     # FIXME: should find referenced __builtins__
     #res = globalvars(_class, recurse=True)
     #assert set(res) == set(['True'])

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -24,7 +24,7 @@ def test_bad_things():
     assert isinstance(d, dict)
     assert list(badobjects(f, 1).keys()) == list(d.keys())
     assert list(errors(f, 1).keys()) == list(d.keys())
-    s = set([(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())])
+    s = {(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())}
     a = dict(s)
     assert len(s) is len(a) # TypeError (and possibly PicklingError)
     n = 1 if IS_PYPY else 2

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -105,15 +105,15 @@ def test_mixins():
   result = ds.importable(quadish, source=True)
   a,b,c,_,result = result.split('\n',4)
   assert result == 'def quad_factory(a=1,b=1,c=0):\n  def dec(f):\n    def func(*args,**kwds):\n      fx = f(*args,**kwds)\n      return a*fx**2 + b*fx + c\n    return func\n  return dec\n\n@quad_factory(a=0,b=4,c=0)\ndef quadish(x):\n  return x+1\n'
-  assert set([a,b,c]) == set(['a = 0', 'c = 0', 'b = 4'])
+  assert {a, b, c} == {'a = 0', 'c = 0', 'b = 4'}
   result = ds.importable(quadratic, source=True)
   a,b,c,result = result.split('\n',3)
   assert result == '\ndef dec(f):\n  def func(*args,**kwds):\n    fx = f(*args,**kwds)\n    return a*fx**2 + b*fx + c\n  return func\n'
-  assert set([a,b,c]) == set(['a = 1', 'c = 0', 'b = 1'])
+  assert {a, b, c} == {'a = 1', 'c = 0', 'b = 1'}
   result = ds.importable(double_add, source=True)
   a,b,c,d,_,result = result.split('\n',5)
   assert result == 'def quad(a=1, b=1, c=0):\n  inverted = [False]\n  def invert():\n    inverted[0] = not inverted[0]\n  def dec(f):\n    def func(*args, **kwds):\n      x = f(*args, **kwds)\n      if inverted[0]: x = -x\n      return a*x**2 + b*x + c\n    func.__wrapped__ = f\n    func.invert = invert\n    func.inverted = inverted\n    return func\n  return dec\n\n@quad(a=0,b=2)\ndef double_add(*args):\n  return sum(args)\n'
-  assert set([a,b,c,d]) == set(['a = 0', 'c = 0', 'b = 2', 'inverted = [True]'])
+  assert {a, b, c, d} == {'a = 0', 'c = 0', 'b = 2', 'inverted = [True]'}
   #*****
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -45,11 +45,11 @@ def pickles(name, exact=False):
                 assert pik == obj
             except AssertionError:
                 assert type(obj) == type(pik)
-                print ("weak: %s %s" % (name, type(obj)))
+                print ("weak: {} {}".format(name, type(obj)))
         else:
             assert type(obj) == type(pik)
     except Exception:
-        print ("fails: %s %s" % (name, type(obj)))
+        print ("fails: {} {}".format(name, type(obj)))
 
 
 def test_objects():

--- a/tests/test_selected.py
+++ b/tests/test_selected.py
@@ -21,7 +21,7 @@ def test_dict_contents():
     ok = dill.pickles(j)
    #except:
    #  print ("FAIL: %s with %s" % (i, dill.detect.errors(j)))
-    if verbose: print ("%s: %s, %s" % (ok, type(j), j))
+    if verbose: print ("{}: {}, {}".format(ok, type(j), j))
     assert ok
   if verbose: print ("")
 
@@ -49,13 +49,13 @@ def test_class_descriptors():
   d = _d.__dict__
   for i in d.values():
     ok = dill.pickles(i)
-    if verbose: print ("%s: %s, %s" % (ok, type(i), i))
+    if verbose: print ("{}: {}, {}".format(ok, type(i), i))
     assert ok
   if verbose: print ("")
   od = _newclass.__dict__
   for i in od.values():
     ok = dill.pickles(i)
-    if verbose: print ("%s: %s, %s" % (ok, type(i), i))
+    if verbose: print ("{}: {}, {}".format(ok, type(i), i))
     assert ok
   if verbose: print ("")
 
@@ -64,10 +64,10 @@ def test_class():
   o = _d()
   oo = _newclass()
   ok = dill.pickles(o)
-  if verbose: print ("%s: %s, %s" % (ok, type(o), o))
+  if verbose: print ("{}: {}, {}".format(ok, type(o), o))
   assert ok
   ok = dill.pickles(oo)
-  if verbose: print ("%s: %s, %s" % (ok, type(oo), oo))
+  if verbose: print ("{}: {}, {}".format(ok, type(oo), oo))
   assert ok
   if verbose: print ("")
 
@@ -78,16 +78,16 @@ def test_frame_related():
   e,t = _f()
   _is = lambda ok: not ok if dill._dill.IS_PYPY else ok
   ok = dill.pickles(f)
-  if verbose: print ("%s: %s, %s" % (ok, type(f), f))
+  if verbose: print ("{}: {}, {}".format(ok, type(f), f))
   assert _is(not ok) #XXX: dill fails
   ok = dill.pickles(g)
-  if verbose: print ("%s: %s, %s" % (ok, type(g), g))
+  if verbose: print ("{}: {}, {}".format(ok, type(g), g))
   assert _is(not ok) #XXX: dill fails
   ok = dill.pickles(t)
-  if verbose: print ("%s: %s, %s" % (ok, type(t), t))
+  if verbose: print ("{}: {}, {}".format(ok, type(t), t))
   assert not ok #XXX: dill fails
   ok = dill.pickles(e)
-  if verbose: print ("%s: %s, %s" % (ok, type(e), e))
+  if verbose: print ("{}: {}, {}".format(ok, type(e), e))
   assert ok
   if verbose: print ("")
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 skip_missing_interpreters=
     True
 envlist =
-    py26
     py27
-    py33
     py34
     py35
     py36


### PR DESCRIPTION
For #260.

In general, supporting and testing EOL versions is becoming increasingly difficult as other packages and tools drop them. 

EOL Pythons (<=2.6, 3.0-3.3) no longer receive security updates, or any updates, from the core Python team. It is possible to upgrade Python on Linux to a supported version for those who care about security. Those who don't can pin to an older version.

Dropping old ones, particularly Python 2.6 (which has been EOL for over 4 years) and 3.2 (2 years), allows code to be updated to use more modern features of Python.

https://en.wikipedia.org/wiki/CPython#Version_history

Also, EOL versions are also little used.

Here's the pip installs for dill from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  70.53% |        223,761 |
| 3.6            |  15.89% |         50,408 |
| 3.5            |   7.16% |         22,715 |
| 3.4            |   6.36% |         20,171 |
| 2.6            |   0.03% |             84 |
| 3.7            |   0.02% |             66 |
| 3.3            |   0.01% |             43 |
| None           |   0.00% |              5 |
| 3.2            |   0.00% |              1 |

Source: `pypinfo --start-date -60 --end-date -30 --percent --pip --markdown dill pyversion`