### PR TITLE
Fixed dump|load_session to take file-like object

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -377,7 +377,10 @@ def dump_session(filename='/tmp/session.pkl', main=None, byref=False):
     from .settings import settings
     protocol = settings['protocol']
     if main is None: main = _main_module
-    f = open(filename, 'wb')
+    if hasattr(filename, 'write'):
+        f = filename
+    else:
+        f = open(filename, 'wb')
     try:
         if byref:
             main = _stash_modules(main)
@@ -388,13 +391,17 @@ def dump_session(filename='/tmp/session.pkl', main=None, byref=False):
         pickler._session = True  # is best indicator of when pickling a session
         pickler.dump(main)
     finally:
-        f.close()
+        if f is not filename:  # If newly opened file
+            f.close()
     return
 
 def load_session(filename='/tmp/session.pkl', main=None):
     """update the __main__ module with the state from the session file"""
     if main is None: main = _main_module
-    f = open(filename, 'rb')
+    if hasattr(filename, 'read'):
+        f = filename
+    else:
+        f = open(filename, 'rb')
     try:
         unpickler = Unpickler(f)
         unpickler._main = main
@@ -404,7 +411,8 @@ def load_session(filename='/tmp/session.pkl', main=None):
         main.__dict__.update(module.__dict__)
         _restore_modules(main)
     finally:
-        f.close()
+        if f is not filename:  # If newly opened file
+            f.close()
     return
 
 ### End: Pickle the Interpreter


### PR DESCRIPTION
## Background

Currently `dump_session`/`load_session` takes filename to specify save/load location.

However, sometimes we want a location to be other than local file, such as remote storage.

In those cases, it'll be very helpful if `dump_session`/`load_session` takes file-like object as argument, just as normal `dump`/`load` do.

## What has changed

Fixed `dump_session` and `load_session` to take file-like object as argument.

## What has not changed

- Did not change argument name from `filename`
  - to keep backward compatibility
- Did not implement `dumps_session`/`loads_session` which returns/takes `bytes` object
  - could be next step to go, but seems too much for now