### PR TITLE
search sys.path when checking if module is builtin / binary

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1256,6 +1256,7 @@ def save_module(pickler, obj):
             builtin_mod = any([obj.__file__.startswith(os.path.normpath(getattr(sys, name)))
                            for name in names if hasattr(sys, name)])
             builtin_mod = builtin_mod or 'site-packages' in obj.__file__
+            builtin_mod = builtin_mod or any(obj.__file__.startswith(os.path.normpath(ppath)) for ppath in sys.path)
         else:
             builtin_mod = True
         if obj.__name__ not in ("builtins", "dill") \


### PR DESCRIPTION
Hi

Not sure of the process to submit PR, so hope this is enough info etc. If not then please let me know!


I came across an issue when we make use of PYTHONPATH to pick up modules and these modules contain shared libraries

Example code

```
import sys

sys.path.insert(0,'path_to_numpy')
sys.path.insert(0,'path_to_dill')

import dill
import numpy

def f():
	ui = numpy.uint64(543)
	print(type(ui))

	with open('d1', 'wb') as f:
	   dill.dump(ui, f)

f()
```

Output 

/usr/local/python/3.6.2/bin/python3 d1.py
<class 'numpy.uint64'>
/u1/morrpat/workspace/libs/1.14.3-cp36/numpy/core/multiarray.cpython-36m-x86_64-linux-gnu.so
Traceback (most recent call last):
  File "d1.py", line 16, in <module>
    f()
  File "d1.py", line 14, in f
    dill.dump(ui, f)
  File "/u1/morrpat/workspace/libs/0.2.7.1/dill/dill.py", line 274, in dump
    pik.dump(obj)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 409, in dump
    self.save(obj)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 521, in save
    self.save_reduce(obj=obj, *rv)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 609, in save_reduce
    save(func)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 476, in save
    f(self, obj) # Call unbound method with explicit self
  File "/u1/morrpat/workspace/libs/0.2.7.1/dill/dill.py", line 1033, in save_builtin_method
    pickler.save_reduce(_get_attr, (module, obj.__name__), obj=obj)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 610, in save_reduce
    save(args)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 476, in save
    f(self, obj) # Call unbound method with explicit self
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 736, in save_tuple
    save(element)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 476, in save
    f(self, obj) # Call unbound method with explicit self
  File "/u1/morrpat/workspace/libs/0.2.7.1/dill/dill.py", line 1239, in save_module
    state=_main_dict)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 634, in save_reduce
    save(state)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 476, in save
    f(self, obj) # Call unbound method with explicit self
  File "/u1/morrpat/workspace/libs/0.2.7.1/dill/dill.py", line 871, in save_module_dict
    StockPickler.save_dict(pickler, obj)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 821, in save_dict
    self._batch_setitems(obj.items())
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 847, in _batch_setitems
    save(v)
  File "/usr/local/python/3.6.2/lib/python3.6/pickle.py", line 496, in save
    rv = reduce(self.proto)
TypeError: can't pickle PyCapsule objects

The fix has it check against all the paths in sys.path as well if it hasnt already determined it is a builtin module.




