### PR TITLE
[#293] Set position to 0 instead of None to prevent TypeError in Python 3

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -955,7 +955,7 @@ def save_attrgetter(pickler, obj):
 
 def _save_file(pickler, obj, open_):
     if obj.closed:
-        position = None
+        position = 0
     else:
         obj.flush()
         if obj in (sys.__stdout__, sys.__stderr__, sys.__stdin__):
@@ -1011,7 +1011,7 @@ if InputType:
     def save_stringi(pickler, obj):
         log.info("Io: %s" % obj)
         if obj.closed:
-            value = ''; position = None
+            value = ''; position = 0
         else:
             value = obj.getvalue(); position = obj.tell()
         pickler.save_reduce(_create_stringi, (value, position, \
@@ -1023,7 +1023,7 @@ if InputType:
     def save_stringo(pickler, obj):
         log.info("Io: %s" % obj)
         if obj.closed:
-            value = ''; position = None
+            value = ''; position = 0
         else:
             value = obj.getvalue(); position = obj.tell()
         pickler.save_reduce(_create_stringo, (value, position, \


### PR DESCRIPTION
This PR fixes `TypeError: unorderable types: NoneType() > int()` which is thrown on Python 3 when comparing the `position` variable with an integer, after `None` has been assigned to it (see #293). 
In Python 3, None is not orderable with integers anymore. We can fix this by assigning 0 instead.