### PR TITLE
Fix shadowed namedtuple bug

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -779,12 +779,9 @@ def _create_array(f, args, state, npdict=None):
     return array
 
 def _create_namedtuple(name, fieldnames, modulename):
-    mod = _import_module(modulename, safe=True)
-    if mod is not None:
-        try:
-            return getattr(mod, name)
-        except:
-            pass
+    class_ = _import_module(modulename + '.' + name, safe=True)
+    if class_ is not None:
+        return class_
     import collections
     t = collections.namedtuple(name, fieldnames)
     t.__module__ = modulename

--- a/tests/shadowed_namedtuple/__init__.py
+++ b/tests/shadowed_namedtuple/__init__.py
@@ -1,0 +1,5 @@
+# This package is used by the `test_shadowed_namedtuple` test.
+# Author: Sergei Fomin (se4min at yandex-team.ru)
+
+from .shadowed import shadowed
+

--- a/tests/shadowed_namedtuple/shadowed.py
+++ b/tests/shadowed_namedtuple/shadowed.py
@@ -1,0 +1,11 @@
+# This module is used by the `test_shadowed_namedtuple` test.
+# Author: Sergei Fomin (se4min at yandex-team.ru)
+
+from collections import namedtuple
+
+class Shadowed(namedtuple("Shadowed", [])):
+    pass
+
+def shadowed():
+    return Shadowed()
+

--- a/tests/test_shadowed_namedtuple.py
+++ b/tests/test_shadowed_namedtuple.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+#
+# Author: Sergei Fomin (se4min at yandex-team.ru)
+
+from dill import dumps, loads
+from shadowed_namedtuple import shadowed
+
+def test_shadowed_namedtuple():
+    obj = shadowed()
+    obj_loaded = loads(dumps(obj))
+    assert obj.__class__ is obj_loaded.__class__
+
+if __name__ == "__main__":
+    test_shadowed_namedtuple()
+


### PR DESCRIPTION
This fixes a case of incorrect unpickling of a namedtuple-derived class instance in a situation when the classes' module path has been shadowed by some other object (see the test provided in the commit for details).

/cc @Kontakter