### PR TITLE
Fix diff bug with oldstyle classes (Python 2)

### DIFF
--- a/dill/__diff.py
+++ b/dill/__diff.py
@@ -36,6 +36,12 @@ builtins_types = set((str, list, dict, set, frozenset, int))
 dont_memo = set(id(i) for i in (memo, sys.modules, sys.path_importer_cache,
              os.environ, id_to_obj))
 
+# InstanceType is a type of all the instances of old-style classes (Python 2).
+try:
+    InstanceType = types.InstanceType
+except AttributeError:
+    # Python 3
+    InstanceType = None
 
 def get_attrs(obj):
     """
@@ -57,7 +63,7 @@ def get_seq(obj, cache={str: False, frozenset: False, list: True, set: True,
     """
     Gets all the items in a sequence or return None
     """
-    o_type = type(obj)
+    o_type = type(obj) if type(obj) is not InstanceType else obj.__class__
     hsattr = hasattr
     if o_type in cache:
         if cache[o_type]:

--- a/dill/__diff.py
+++ b/dill/__diff.py
@@ -36,12 +36,6 @@ builtins_types = set((str, list, dict, set, frozenset, int))
 dont_memo = set(id(i) for i in (memo, sys.modules, sys.path_importer_cache,
              os.environ, id_to_obj))
 
-# InstanceType is a type of all the instances of old-style classes (Python 2).
-try:
-    InstanceType = types.InstanceType
-except AttributeError:
-    # Python 3
-    InstanceType = None
 
 def get_attrs(obj):
     """
@@ -63,7 +57,10 @@ def get_seq(obj, cache={str: False, frozenset: False, list: True, set: True,
     """
     Gets all the items in a sequence or return None
     """
-    o_type = type(obj) if type(obj) is not InstanceType else obj.__class__
+    try:
+        o_type = obj.__class__
+    except AttributeError:
+        o_type = type(obj)
     hsattr = hasattr
     if o_type in cache:
         if cache[o_type]:


### PR DESCRIPTION
This fixes a bug in `__diff` module when it decides if an object is iterable or not. The problem is that it caches the result (`True` or `False`) for a type, but all the old-style class instances have the same type `<type 'instance'>`, so the first such an object that is passed to `get_seq` function determines the result for all the instances of all the old-style classes.

Also notice `#XXX` on `__diff.py:105` - maybe it has been added to alleviate the problem fixed in this commit?

/cc @Kontakter