### PR TITLE
Add support for pickling MappingProxyType on Python3

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -798,7 +798,8 @@ def _getattr(objclass, name, repr_str):
     except:
         try:
             attr = objclass.__dict__
-            if type(attr) is DictProxyType:
+            if (sys.hexversion < 0x30300f0 and type(attr) is DictProxyType) or \
+               (sys.hexversion >= 0x30300f0 and type(attr) is MappingProxyType):
                 attr = attr[name]
             else:
                 attr = getattr(objclass,name)

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -49,7 +49,8 @@ if PY3: #XXX: get types from .objtypes ?
         from threading import _RLock as RLockType
    #from io import IOBase
     from types import CodeType, FunctionType, MethodType, GeneratorType, \
-        TracebackType, FrameType, ModuleType, BuiltinMethodType
+        TracebackType, FrameType, ModuleType, BuiltinMethodType, \
+        MappingProxyType
     BufferType = memoryview #XXX: unregistered
     ClassType = type # no 'old-style' classes
     EllipsisType = type(Ellipsis)
@@ -58,7 +59,8 @@ if PY3: #XXX: get types from .objtypes ?
     SliceType = slice
     TypeType = type # 'new-style' classes #XXX: unregistered
     XRangeType = range
-    DictProxyType = type(object.__dict__)
+    if sys.hexversion < 0x30300f0:
+        DictProxyType = type(object.__dict__)
 else:
     import __builtin__
     from pickle import Pickler as StockPickler, Unpickler as StockUnpickler
@@ -1138,22 +1140,31 @@ def save_cell(pickler, obj):
     log.info("# Ce")
     return
 
-# The following function is based on 'saveDictProxy' from spickle
-# Copyright (c) 2011 by science+computing ag
-# License: http://www.apache.org/licenses/LICENSE-2.0
 if not IS_PYPY:
-    @register(DictProxyType)
-    def save_dictproxy(pickler, obj):
-        log.info("Dp: %s" % obj)
-        attr = obj.get('__dict__')
-       #pickler.save_reduce(_create_dictproxy, (attr,'nested'), obj=obj)
-        if type(attr) == GetSetDescriptorType and attr.__name__ == "__dict__" \
-        and getattr(attr.__objclass__, "__dict__", None) == obj:
-            pickler.save_reduce(getattr, (attr.__objclass__,"__dict__"),obj=obj)
-            log.info("# Dp")
+    if sys.hexversion >= 0x30300f0:
+        @register(MappingProxyType)
+        def save_mappingproxy(pickler, obj):
+            log.info("Mp: %s" % obj)
+            pickler.save_reduce(MappingProxyType, (obj.copy(),), obj=obj)
+            log.info("# Mp")
             return
-        # all bad below... so throw ReferenceError or TypeError
-        raise ReferenceError("%s does not reference a class __dict__" % obj)
+    else:
+        # The following function is based on 'saveDictProxy' from spickle
+        # Copyright (c) 2011 by science+computing ag
+        # License: http://www.apache.org/licenses/LICENSE-2.0
+        @register(DictProxyType)
+        def save_dictproxy(pickler, obj):
+            log.info("Dp: %s" % obj)
+            attr = obj.get('__dict__')
+           #pickler.save_reduce(_create_dictproxy, (attr,'nested'), obj=obj)
+            if type(attr) == GetSetDescriptorType and attr.__name__ == "__dict__" \
+            and getattr(attr.__objclass__, "__dict__", None) == obj:
+                pickler.save_reduce(getattr, (attr.__objclass__,"__dict__"),obj=obj)
+                log.info("# Dp")
+                return
+            # all bad below... so throw ReferenceError or TypeError
+            raise ReferenceError("%s does not reference a class __dict__" % obj)
+
 
 @register(SliceType)
 def save_slice(pickler, obj):


### PR DESCRIPTION
I tried to pickle `MappingProxyType`, which is a built-in type on Python3, but got the following error:

```
$ ipython
Python 3.6.8 (default, Jan 14 2019, 11:02:34) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.6.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import dill                                                                                                                               

In [2]: dill.__version__                                                                                                                          
Out[2]: '0.3.0'

In [3]: from types import MappingProxyType                                                                                                        

In [4]: m = MappingProxyType({"foo": "bar"})                                                                                                      

In [5]: dill.dumps(m)                                                                                                                             
---------------------------------------------------------------------------
ReferenceError                            Traceback (most recent call last)
<ipython-input-5-3d1f79b6b605> in <module>
----> 1 dill.dumps(m)

~/venv/dill/lib/python3.6/site-packages/dill/_dill.py in dumps(obj, protocol, byref, fmode, recurse)
    292     """pickle an object to a string"""
    293     file = StringIO()
--> 294     dump(obj, file, protocol, byref, fmode, recurse)#, strictio)
    295     return file.getvalue()
    296 

~/venv/dill/lib/python3.6/site-packages/dill/_dill.py in dump(obj, file, protocol, byref, fmode, recurse)
    285         raise PicklingError(msg)
    286     else:
--> 287         pik.dump(obj)
    288     stack.clear()  # clear record of 'recursion-sensitive' pickled objects
    289     return

/usr/lib/python3.6/pickle.py in dump(self, obj)
    407         if self.proto >= 4:
    408             self.framer.start_framing()
--> 409         self.save(obj)
    410         self.write(STOP)
    411         self.framer.end_framing()

/usr/lib/python3.6/pickle.py in save(self, obj, save_persistent_id)
    474         f = self.dispatch.get(t)
    475         if f is not None:
--> 476             f(self, obj) # Call unbound method with explicit self
    477             return
    478 

~/venv/dill/lib/python3.6/site-packages/dill/_dill.py in save_dictproxy(pickler, obj)
   1154             return
   1155         # all bad below... so throw ReferenceError or TypeError
-> 1156         raise ReferenceError("%s does not reference a class __dict__" % obj)
   1157 
   1158 @register(SliceType)

ReferenceError: {'foo': 'bar'} does not reference a class __dict__
```

This root cause seems to be the following code:

```
  42 if PY3: #XXX: get types from .objtypes ?

(snip)

  61     DictProxyType = type(object.__dict__)
```

```
1144 if not IS_PYPY:
1145     @register(DictProxyType)
1146     def save_dictproxy(pickler, obj):
1147         log.info("Dp: %s" % obj)
1148         attr = obj.get('__dict__')
1149        #pickler.save_reduce(_create_dictproxy, (attr,'nested'), obj=obj)
1150         if type(attr) == GetSetDescriptorType and attr.__name__ == "__dict__" \
1151         and getattr(attr.__objclass__, "__dict__", None) == obj:
1152             pickler.save_reduce(getattr, (attr.__objclass__,"__dict__"),obj=obj)
1153             log.info("# Dp")
1154             return
1155         # all bad below... so throw ReferenceError or TypeError
1156         raise ReferenceError("%s does not reference a class __dict__" % obj)
```

`object.__dict__` returned `dict_proxy` object until Python 3.2, but [it's replaced with MappingProxyType from 3.3](https://hg.python.org/cpython/rev/c3a0197256ee). And `MappingProxyType` doesn't have a `__dict__` attribute, so `save_dictproxy` fails. This PR fixes this problem and makes `MappingProxyType` serializable.