### PR TITLE
Fix pickling keyword only arguments

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -579,13 +579,15 @@ def _load_type(name):
 def _create_type(typeobj, *args):
     return typeobj(*args)
 
-def _create_function(fcode, fglobals, fname=None, fdefaults=None, \
-                                      fclosure=None, fdict=None):
+def _create_function(fcode, fglobals, fname=None, fdefaults=None,
+                     fclosure=None, fdict=None, fkwdefaults=None):
     # same as FunctionType, but enable passing __dict__ to new function,
     # __dict__ is the storehouse for attributes added after function creation
     if fdict is None: fdict = dict()
     func = FunctionType(fcode, fglobals or dict(), fname, fdefaults, fclosure)
     func.__dict__.update(fdict) #XXX: better copy? option to copy?
+    if fkwdefaults is not None:
+        func.__kwdefaults__ = fkwdefaults
     return func
 
 def _create_ftype(ftypeobj, func, args, kwds):
@@ -1388,10 +1390,11 @@ def save_function(pickler, obj):
             _super = ('super' in getattr(obj.__code__,'co_names',())) and (_byref is not None)
             if _super: pickler._byref = True
             if _memo: pickler._recurse = False
+            fkwdefaults = getattr(obj, '__kwdefaults__', None)
             pickler.save_reduce(_create_function, (obj.__code__,
                                 globs, obj.__name__,
                                 obj.__defaults__, obj.__closure__,
-                                obj.__dict__), obj=obj)
+                                obj.__dict__, fkwdefaults), obj=obj)
         else:
             _super = ('super' in getattr(obj.func_code,'co_names',())) and (_byref is not None) and getattr(pickler, '_recurse', False)
             if _super: pickler._byref = True

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+
+import dill
+import sys
+dill.settings['recurse'] = True
+
+
+def is_py3():
+    return hex(sys.hexversion) >= '0x30000f0'
+
+
+def function_a(a):
+    return a
+
+
+def function_b(b, b1):
+    return b + b1
+
+
+def function_c(c, c1=1):
+    return c + c1
+
+
+def function_d(d, d1, d2=1):
+    return d + d1 + d2
+
+
+if is_py3():
+    exec('''
+def function_e(e, *e1, e2=1, e3=2):
+    return e + sum(e1) + e2 + e3''')
+
+
+def test_functions():
+    dumped_func_a = dill.dumps(function_a)
+    assert dill.loads(dumped_func_a)(0) == 0
+
+    dumped_func_b = dill.dumps(function_b)
+    assert dill.loads(dumped_func_b)(1,2) == 3
+
+    dumped_func_c = dill.dumps(function_c)
+    assert dill.loads(dumped_func_c)(1) == 2
+    assert dill.loads(dumped_func_c)(1, 2) == 3
+
+    dumped_func_d = dill.dumps(function_d)
+    assert dill.loads(dumped_func_d)(1, 2) == 4
+    assert dill.loads(dumped_func_d)(1, 2, 3) == 6
+    assert dill.loads(dumped_func_d)(1, 2, d2=3) == 6
+
+    if is_py3():
+        exec('''
+dumped_func_e = dill.dumps(function_e)
+assert dill.loads(dumped_func_e)(1, 2) == 6
+assert dill.loads(dumped_func_e)(1, 2, 3) == 9
+assert dill.loads(dumped_func_e)(1, 2, e2=3) == 8
+assert dill.loads(dumped_func_e)(1, 2, e2=3, e3=4) == 10
+assert dill.loads(dumped_func_e)(1, 2, 3, e2=4) == 12
+assert dill.loads(dumped_func_e)(1, 2, 3, e2=4, e3=5) == 15''')
+
+
+if __name__ == '__main__':
+    test_functions()


### PR DESCRIPTION
This PR fixes issue #313, failing to pickle keyword-only arguments, and test checking functions to be dumped and loaded correctly is added.
And I reluctantly used `exec` in the test to avoid syntax error with Python 2.x.
If there is better way, please point out.