### PR TITLE
Simplify CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,48 @@
 language: python
 
-sudo: false
-
 matrix:
     include:
         - python: '2.5'
           dist: trusty
-          sudo: false
           env:
 
         - python: '2.6'
           dist: trusty
-          sudo: false
           env:
 
         - python: '2.7'
           dist: trusty
-          sudo: false
           env:
             - COVERAGE="true"
             - NUMPY="true"
 
         - python: '3.1'
           dist: trusty
-          sudo: false
           env:
 
         - python: '3.2'
           dist: trusty
-          sudo: false
           env:
 
         - python: '3.3'
           dist: trusty
-          sudo: false
           env:
 
         - python: '3.4'
           dist: trusty
-          sudo: false
           env:
 
         - python: '3.5'
           dist: trusty
-          sudo: false
           env:
             - COVERAGE="true"
 
         - python: '3.6'
           dist: trusty
-          sudo: false
           env:
 
         - python: '3.7'
           dist: xenial
-          sudo: true
           env:
 
         - python: '3.8'
@@ -64,22 +52,18 @@ matrix:
 
         - python: '3.9-dev'
           dist: xenial
-          sudo: true
           env:
 
         - python: 'nightly'
           dist: xenial
-          sudo: true
           env:
 
         - python: 'pypy'
           dist: trusty
-          sudo: false
           env:
 
         - python: 'pypy3'
           dist: trusty
-          sudo: false
           env:
 
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,36 @@
+dist: trusty
 language: python
 
 matrix:
     include:
         - python: '2.5'
-          dist: trusty
           env:
 
         - python: '2.6'
-          dist: trusty
           env:
 
         - python: '2.7'
-          dist: trusty
           env:
             - COVERAGE="true"
             - NUMPY="true"
 
         - python: '3.1'
-          dist: trusty
           env:
 
         - python: '3.2'
-          dist: trusty
           env:
 
         - python: '3.3'
-          dist: trusty
           env:
 
         - python: '3.4'
-          dist: trusty
           env:
 
         - python: '3.5'
-          dist: trusty
           env:
             - COVERAGE="true"
 
         - python: '3.6'
-          dist: trusty
           env:
 
         - python: '3.7'
@@ -59,11 +51,9 @@ matrix:
           env:
 
         - python: 'pypy'
-          dist: trusty
           env:
 
         - python: 'pypy3'
-          dist: trusty
           env:
 
     allow_failures:


### PR DESCRIPTION
* `sudo:` is no longer needed: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

* Default to `trusty`, explicitly use `xenial` where required
