### PR TITLE
Add slice type to  reverse typemap

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -555,6 +555,7 @@ _reverse_typemap.update({
     'PyBufferedReaderType': PyBufferedReaderType,
     'PyBufferedWriterType': PyBufferedWriterType,
     'PyTextWrapperType': PyTextWrapperType,
+    'SliceType': SliceType,
 })
 if ExitType:
     _reverse_typemap['ExitType'] = ExitType


### PR DESCRIPTION
SliceType was missing from _reverse_typemap, which led to `KeyError: 'SliceType'` when `_load_type` is called. I add SliceType to _reverse_typemap explicitly