### PR TITLE
Allow 3.7 Pickles to be Loaded in 3.8

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -534,6 +534,23 @@ def use_diff(on=True):
             import diff as d
         diff = d
 
+def _create_code(*args):
+    if PY3 and hasattr(args[-3], 'encode'): #FIXME: from PY2 fails (optcode)
+        args = list(args)
+        args[-3] = args[-3].encode() # co_lnotab
+        args[-10] = args[-10].encode() # co_code
+    if hasattr(CodeType, 'co_posonlyargcount'):
+        if len(args) == 16: return CodeType(*args)
+        elif len(args) == 15: return CodeType(args[0], 0, *args[1:])
+        return CodeType(args[0], 0, 0, *args[1:])
+    elif hasattr(CodeType, 'co_kwonlyargcount'):
+        if len(args) == 16: return CodeType(args[0], *args[2:])
+        elif len(args) == 15: return CodeType(*args)
+        return CodeType(args[0], 0, *args[1:])
+    if len(args) == 16: return CodeType(args[0], *args[3:])
+    elif len(args) == 15: return CodeType(args[0], *args[2:])
+    return CodeType(*args)
+
 def _create_typemap():
     import types
     if PY3:
@@ -565,6 +582,7 @@ _reverse_typemap.update({
     'PyBufferedReaderType': PyBufferedReaderType,
     'PyBufferedWriterType': PyBufferedWriterType,
     'PyTextWrapperType': PyTextWrapperType,
+    'CodeType': _create_code,
 })
 if ExitType:
     _reverse_typemap['ExitType'] = ExitType
@@ -601,23 +619,6 @@ def _create_function(fcode, fglobals, fname=None, fdefaults=None,
     if fkwdefaults is not None:
         func.__kwdefaults__ = fkwdefaults
     return func
-
-def _create_code(*args):
-    if PY3 and hasattr(args[-3], 'encode'): #FIXME: from PY2 fails (optcode)
-        args = list(args)
-        args[-3] = args[-3].encode() # co_lnotab
-        args[-10] = args[-10].encode() # co_code
-    if hasattr(CodeType, 'co_posonlyargcount'):
-        if len(args) == 16: return CodeType(*args)
-        elif len(args) == 15: return CodeType(args[0], 0, *args[1:])
-        return CodeType(args[0], 0, 0, *args[1:])
-    elif hasattr(CodeType, 'co_kwonlyargcount'):
-        if len(args) == 16: return CodeType(args[0], *args[2:])
-        elif len(args) == 15: return CodeType(*args)
-        return CodeType(args[0], 0, *args[1:])
-    if len(args) == 16: return CodeType(args[0], *args[3:])
-    elif len(args) == 15: return CodeType(args[0], *args[2:])
-    return CodeType(*args)
 
 def _create_ftype(ftypeobj, func, args, kwds):
     if kwds is None:


### PR DESCRIPTION
Use `_create_code` Logic when loading pickled objects rather than just the builtin `CodeType`. If the pickle file was created using, e.g., Python 3.7 then the serialized object will 15 arguments (missing `co_posonlyargcount`) but the version in the current (Python 3.8) interpreter expects 16. This PR just fills in a zero.


Related issues: #357 #318 #394 cloudpipe/cloudpickle#396