### PR TITLE
Resolve symlinks when determining if module is builtin

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1360,7 +1360,7 @@ def save_module(pickler, obj):
         if hasattr(obj, "__file__"):
             names = ["base_prefix", "base_exec_prefix", "exec_prefix",
                      "prefix", "real_prefix"]
-            builtin_mod = any(obj.__file__.startswith(os.path.normpath(getattr(sys, name)))
+            builtin_mod = any(obj.__file__.startswith(os.path.realpath(getattr(sys, name)))
                               for name in names if hasattr(sys, name))
             builtin_mod = (builtin_mod or obj.__file__.endswith(EXTENSION_SUFFIXES) or
                            'site-packages' in obj.__file__)


### PR DESCRIPTION
To determine whether a module is builtin, Dill compares `mod.__file__`
against `sys.base_prefix`. The former will have symlinks resolved, while
the latter will not. This causes builtin module detection to fail in
Python installations where `sys.base_prefix` involves symlinks, like
Homebrew-managed Python on macOS.

This commit resolves the issue by resolving symlinks in
`sys.base_prefix` before comparing module paths against it.

Fix #417.