### PR TITLE
Issue 332 abc data

### DIFF
--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+"""
+test dill's ability to pickle abstract base class objects
+"""
+import dill as pickle
+import abc
+
+from types import FunctionType
+
+pickle.settings['recurse'] = True
+
+class OneTwoThree(abc.ABC):
+    @abc.abstractmethod
+    def foo(self):
+        """A method"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def bar(self):
+        """Property getter"""
+        pass
+
+    @bar.setter
+    @abc.abstractmethod
+    def bar(self, value):
+        """Property setter"""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def cfoo(cls):
+        """Class method"""
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def sfoo():
+        """Static method"""
+        pass
+
+class EasyAsAbc(OneTwoThree):
+    def __init__(self):
+        self._bar = None
+
+    def foo(self):
+        return "Instance Method FOO"
+
+    @property
+    def bar(self):
+        return self._bar
+
+    @bar.setter
+    def bar(self, value):
+        self._bar = value
+
+    @classmethod
+    def cfoo(cls):
+        return "Class Method CFOO"
+
+    @staticmethod
+    def sfoo():
+        return "Static Method SFOO"
+
+def test_abc_non_local():
+    assert pickle.loads(pickle.dumps(OneTwoThree)) == OneTwoThree
+    assert pickle.loads(pickle.dumps(EasyAsAbc)) == EasyAsAbc
+    instance = EasyAsAbc()
+    # Set a property that StockPickle can't preserve
+    instance.bar = lambda x: x**2
+    depickled = pickle.loads(pickle.dumps(instance))
+    assert type(depickled) == type(instance)
+    assert type(depickled.bar) == FunctionType
+    assert depickled.bar(3) == 9
+    assert depickled.sfoo() == "Static Method SFOO"
+    assert depickled.cfoo() == "Class Method CFOO"
+    assert depickled.foo() == "Instance Method FOO"
+    print("Tada")
+
+def test_abc_local():
+    """
+    Test using locally scoped ABC class
+    """
+    class LocalABC(abc.ABC):
+        @abc.abstractmethod
+        def foo(self):
+            pass
+
+    res = pickle.dumps(LocalABC)
+    pik = pickle.loads(res)
+    assert type(pik) == type(LocalABC)
+    # TODO should work like it does for non local classes
+    # <class '__main__.LocalABC'>
+    # <class '__main__.test_abc_local.<locals>.LocalABC'>
+
+    class Real(pik):
+        def foo(self):
+            return "True!"
+
+    real = Real()
+    assert real.foo() == "True!"
+
+    try:
+        pik()
+    except TypeError as e:
+        print("Tada: ", e)
+    else:
+        print('Failed to raise type error')
+        assert False
+
+def test_meta_local_no_cache():
+    """
+    Test calling metaclass and cache registration
+    """
+    LocalMetaABC = abc.ABCMeta('LocalMetaABC', (), {})
+
+    class ClassyClass:
+        pass
+
+    class KlassyClass:
+      pass
+
+    LocalMetaABC.register(ClassyClass)
+
+    assert not issubclass(KlassyClass, LocalMetaABC)
+    assert issubclass(ClassyClass, LocalMetaABC)
+
+    res = pickle.dumps(LocalMetaABC)
+    assert b"ClassyClass" in res
+    assert b"KlassyClass" not in res
+
+    pik = pickle.loads(res)
+    assert type(pik) == type(LocalMetaABC)
+
+    pik.register(ClassyClass)  # TODO: test should pass without calling register again
+    assert not issubclass(KlassyClass, pik)
+    assert issubclass(ClassyClass, pik)
+    print("tada")
+
+if __name__ == '__main__':
+    test_abc_non_local()
+    test_abc_local()
+    test_meta_local_no_cache()


### PR DESCRIPTION
Resolves #332 

Register ABCMeta to use StockPickler. If workable, this is preferable to the [cloudpickle](https://github.com/cloudpipe/cloudpickle/blob/343da119685f622da2d1658ef7b3e2516a01817f/cloudpickle/cloudpickle_fast.py#L182-L201) solution that depends heavily on the internals of the ABC implementation.

This will remain broken on some versions of [Python 3.7](https://stackoverflow.com/questions/60583118/serialize-subclass-of-abstract-class-in-python-3-7-1) that did not support pickling the new c implementation of ABC.

Issues:
- Registering ABCMeta seems to exclude other registered types, for instance the module/locality solution for ClassType (see broken test)
- Need to confirm expected behavior for ABC registry once locality issue is solved
