### PR TITLE
Pickle inner `collections.namedtuple`s and function attributes

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1777,8 +1777,12 @@ def save_type(pickler, obj, postproc_list=None):
            #print ("%s\n%s" % (obj.__bases__, obj.__dict__))
             for name in _dict.get("__slots__", []):
                 del _dict[name]
+            if PY3 and obj_name != obj.__name__:
+                if postproc_list is None:
+                    postproc_list = []
+                postproc_list.append((setattr, (obj, '__qualname__', obj_name)))
             _save_with_postproc(pickler, (_create_type, (
-                type(obj), obj_name, obj.__bases__, _dict
+                type(obj), obj.__name__, obj.__bases__, _dict
             )), obj=obj, postproc_list=postproc_list)
             log.info("# %s" % _t)
         else:

--- a/tests/test_classdef.py
+++ b/tests/test_classdef.py
@@ -114,6 +114,13 @@ def test_namedtuple():
     assert Bad._fields == dill.loads(dill.dumps(Bad))._fields
     assert tuple(Badi) == tuple(dill.loads(dill.dumps(Badi)))
 
+    class A:
+        class B(namedtuple("B", ["one", "two"])):
+            pass
+
+    a = A()
+    assert dill.copy(a)
+
 def test_dtype():
     try:
         import numpy as np

--- a/tests/test_classdef.py
+++ b/tests/test_classdef.py
@@ -116,10 +116,17 @@ def test_namedtuple():
 
     class A:
         class B(namedtuple("B", ["one", "two"])):
-            pass
+            '''docstring'''
+        B.__module__ = 'testing'
 
     a = A()
     assert dill.copy(a)
+
+    assert dill.copy(A.B).__name__ == 'B'
+    if dill._dill.PY3:
+        assert dill.copy(A.B).__qualname__.endswith('.<locals>.A.B')
+    assert dill.copy(A.B).__doc__ == 'docstring'
+    assert dill.copy(A.B).__module__ == 'testing'
 
 def test_dtype():
     try:
@@ -134,7 +141,7 @@ def test_dtype():
 def test_array_nested():
     try:
         import numpy as np
-    
+
         x = np.array([1])
         y = (x,)
         dill.dumps(x)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -27,7 +27,10 @@ def function_c(c, c1=1):
 
 
 def function_d(d, d1, d2=1):
+    """doc string"""
     return d + d1 + d2
+
+function_d.__module__ = 'a module'
 
 
 if is_py3():
@@ -54,6 +57,8 @@ def test_functions():
     assert dill.loads(dumped_func_c)(1, 2) == 3
 
     dumped_func_d = dill.dumps(function_d)
+    assert dill.loads(dumped_func_d).__doc__ == function_d.__doc__
+    assert dill.loads(dumped_func_d).__module__ == function_d.__module__
     assert dill.loads(dumped_func_d)(1, 2) == 4
     assert dill.loads(dumped_func_d)(1, 2, 3) == 6
     assert dill.loads(dumped_func_d)(1, 2, d2=3) == 6


### PR DESCRIPTION
1) Fixing pickling of `collections.namedtuple` subclasses
2) Fixes pickling `collections.namedtuple` when `__qualname__` is not `__name__`
3) Saves nonessential attributes of function objects by name instead arguments to the `_create_function` (supersedes #422) 
4) Pickles defaults of `collections.namedtuple` classes

I think it is worth debating if this is the best way to handle new attributes to the function class. Some functions have `__annotations__` but not `__kwdefaults__`. In the future, if these new attributes don't scale well, the current solution of adding them to `_create_function` could likely lead to a mess. On the other hand, these new strings would be added to all pickles whose functions that use said attributes. When many functions are pickled in one pickle, this overhead is constant. However, when pickling many functions in separate pickles, the overhead becomes linear in the number of functions. This cost should be considered.

This PR also adds a breaking change. Previously, `_create_namedtuple` did not save and use the default values of the tuple. In order to add the argument to this function to support it, pickling a `collections.namedtuple` with default values using this PR and trying to unpickle it in an older version of dill will fail.

Fixes #288, Fixes #420