### PR TITLE
Support `dict` views and `functools.lru_cache`

### DIFF
--- a/tests/test_dictviews.py
+++ b/tests/test_dictviews.py
@@ -7,7 +7,7 @@
 #  - https://github.com/uqfoundation/dill/blob/master/LICENSE
 
 import dill
-from dill._dill import OLD310
+from dill._dill import OLD310, MAPPING_PROXY_TRICK
 
 def test_dictviews():
     x = {'a': 1}
@@ -16,7 +16,7 @@ def test_dictviews():
     assert dill.copy(x.items())
 
 def test_dictproxy_trick():
-    if not OLD310:
+    if not OLD310 and MAPPING_PROXY_TRICK:
         x = {'a': 1}
         all_views = (x.values(), x.items(), x.keys(), x)
         seperate_views = dill.copy(all_views)

--- a/tests/test_dictviews.py
+++ b/tests/test_dictviews.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2008-2016 California Institute of Technology.
+# Copyright (c) 2016-2021 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/dill/blob/master/LICENSE
+
+import dill
+from dill._dill import OLD310
+
+def test_dictviews():
+    x = {'a': 1}
+    assert dill.copy(x.keys())
+    assert dill.copy(x.values())
+    assert dill.copy(x.items())
+
+def test_dictproxy_trick():
+    if not OLD310:
+        x = {'a': 1}
+        all_views = (x.values(), x.items(), x.keys(), x)
+        seperate_views = dill.copy(all_views)
+        new_x = seperate_views[-1]
+        new_x['b'] = 2
+        new_x['c'] = 1
+        assert len(new_x) == 3 and len(x) == 1
+        assert len(seperate_views[0]) == 3 and len(all_views[0]) == 1
+        assert len(seperate_views[1]) == 3 and len(all_views[1]) == 1
+        assert len(seperate_views[2]) == 3 and len(all_views[2]) == 1
+        assert dict(all_views[1]) == x
+        assert dict(seperate_views[1]) == new_x
+
+if __name__ == '__main__':
+    test_dictviews()
+    test_dictproxy_trick()


### PR DESCRIPTION
1) Implement save functions for dictionary view objects and LRU caches
2) Add trick to extract the dictionary directly from a `types.MappingProxyType` in CPython 3.9+
3) Use trick to preserve reference structure for dictionary view objects in Python 3.10+

Fixes #353