### PR TITLE
Fix dill.source.getsource compatibility for IPython interactive session.

### DIFF
--- a/dill/source.py
+++ b/dill/source.py
@@ -27,6 +27,7 @@ import re
 from inspect import (getblock, getfile, getmodule, getsourcefile, indentsize,
                      isbuiltin, isclass, iscode, isframe, isfunction, ismethod,
                      ismodule, istraceback)
+from inspect import getsource as inspect_getsource
 from tokenize import TokenError
 
 from ._dill import PY3
@@ -127,8 +128,14 @@ def findsource(object):
                 err += ", please install 'pyreadline'"
         if err:
             raise IOError(err)
-        lbuf = readline.get_current_history_length()
-        lines = [readline.get_history_item(i)+'\n' for i in range(1,lbuf)]
+
+        if hasattr(module, 'get_ipython'):
+            if isfunction(object):
+                return [''.join(inspect_getsource(object))], 0
+            lines = module.get_ipython().history_manager.input_hist_raw
+        else:
+            lbuf = readline.get_current_history_length()
+            lines = [readline.get_history_item(i)+'\n' for i in range(1,lbuf)]
     else:
         try: # special handling for class instances
             if not isclass(object) and isclass(type(object)): # __class__


### PR DESCRIPTION
I propose a little fix for `dill.source.getsource` for IPython compatibility. It allows to retrieve function and class source code in IPython interactive session. The fix solves the following issue in IPython shell.

```
In [1]: import dill

In [2]: def foo():
   ...:     return 0
   ...: 

In [3]: class Bar:
   ...:     pass
   ...: 

In [5]: dill.source.getsource(foo)
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 dill.source.getsource(foo)

File ~/.local/lib/python3.10/site-packages/dill/source.py:354, in getsource(object, alias, lstrip, enclosing, force, builtin)
    352 # get source lines; if fail, try to 'force' an import
    353 try: # fails for builtins, and other assorted object types
--> 354     lines, lnum = getsourcelines(object, enclosing=enclosing)
    355 except (TypeError, IOError): # failed to get source, resort to import hooks
    356     if not force: # don't try to get types that findsource can't get

File ~/.local/lib/python3.10/site-packages/dill/source.py:325, in getsourcelines(object, lstrip, enclosing)
    312 def getsourcelines(object, lstrip=False, enclosing=False):
    313     """Return a list of source lines and starting line number for an object.
    314     Interactively-defined objects refer to lines in the interpreter's history.
    315 
   (...)
    323     If lstrip=True, ensure there is no indentation in the first line of code.
    324     If enclosing=True, then also return any enclosing code."""
--> 325     code, n = getblocks(object, lstrip=lstrip, enclosing=enclosing, locate=True)
    326     return code[-1], n[-1]

File ~/.local/lib/python3.10/site-packages/dill/source.py:251, in getblocks(object, lstrip, enclosing, locate)
    241 def getblocks(object, lstrip=False, enclosing=False, locate=False):
    242     """Return a list of source lines and starting line number for an object.
    243     Interactively-defined objects refer to lines in the interpreter's history.
    244 
   (...)
    249     DEPRECATED: use 'getsourcelines' instead
    250     """
--> 251     lines, lnum = findsource(object)
    253     if ismodule(object):
    254         if lstrip: lines = _outdent(lines)

File ~/.local/lib/python3.10/site-packages/dill/source.py:154, in findsource(object)
    151         lines = linecache.getlines(file)
    153 if not lines:
--> 154     raise IOError('could not extract source code')
    156 #FIXME: all below may fail if exec used (i.e. exec('f = lambda x:x') )
    157 if ismodule(object):

OSError: could not extract source code

In [6]: dill.source.getsource(Bar)
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
Input In [6], in <cell line: 1>()
----> 1 dill.source.getsource(Bar)

File ~/.local/lib/python3.10/site-packages/dill/source.py:354, in getsource(object, alias, lstrip, enclosing, force, builtin)
    352 # get source lines; if fail, try to 'force' an import
    353 try: # fails for builtins, and other assorted object types
--> 354     lines, lnum = getsourcelines(object, enclosing=enclosing)
    355 except (TypeError, IOError): # failed to get source, resort to import hooks
    356     if not force: # don't try to get types that findsource can't get

File ~/.local/lib/python3.10/site-packages/dill/source.py:325, in getsourcelines(object, lstrip, enclosing)
    312 def getsourcelines(object, lstrip=False, enclosing=False):
    313     """Return a list of source lines and starting line number for an object.
    314     Interactively-defined objects refer to lines in the interpreter's history.
    315 
   (...)
    323     If lstrip=True, ensure there is no indentation in the first line of code.
    324     If enclosing=True, then also return any enclosing code."""
--> 325     code, n = getblocks(object, lstrip=lstrip, enclosing=enclosing, locate=True)
    326     return code[-1], n[-1]

File ~/.local/lib/python3.10/site-packages/dill/source.py:251, in getblocks(object, lstrip, enclosing, locate)
    241 def getblocks(object, lstrip=False, enclosing=False, locate=False):
    242     """Return a list of source lines and starting line number for an object.
    243     Interactively-defined objects refer to lines in the interpreter's history.
    244 
   (...)
    249     DEPRECATED: use 'getsourcelines' instead
    250     """
--> 251     lines, lnum = findsource(object)
    253     if ismodule(object):
    254         if lstrip: lines = _outdent(lines)

File ~/.local/lib/python3.10/site-packages/dill/source.py:154, in findsource(object)
    151         lines = linecache.getlines(file)
    153 if not lines:
--> 154     raise IOError('could not extract source code')
    156 #FIXME: all below may fail if exec used (i.e. exec('f = lambda x:x') )
    157 if ismodule(object):

OSError: could not extract source code
```