### PR TITLE
Fix class cell in `__new__` for metaclasses

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1589,7 +1589,13 @@ def save_cell(pickler, obj):
         log.info("# Ce3")
         return
     if is_dill(pickler, child=True):
-        postproc = next(iter(pickler._postproc.values()), None)
+        if id(f) in pickler._postproc:
+            # Already seen. Add to its postprocessing.
+            postproc = pickler._postproc[id(f)]
+        else:
+            # Haven't seen it. Add to the highest possible object and set its
+            # value as late as possible to prevent cycle.
+            postproc = next(iter(pickler._postproc.values()), None)
         if postproc is not None:
             log.info("Ce2: %s" % obj)
             # _CELL_REF is defined in _shims.py to support older versions of

--- a/tests/test_classdef.py
+++ b/tests/test_classdef.py
@@ -217,16 +217,16 @@ def test_slots():
     assert dill.copy(y).y == value
 
 def test_metaclass():
-    class metaclass_with_new(type):
-        def __new__(mcls, name, bases, ns, **kwds):
-            cls = super().__new__(mcls, name, bases, ns, **kwds)
-            assert mcls is not None
-            assert cls.method(mcls)
-            return cls
-        def method(cls, mcls):
-            return isinstance(cls, mcls)
-
     if dill._dill.PY3:
+        class metaclass_with_new(type):
+            def __new__(mcls, name, bases, ns, **kwds):
+                cls = super().__new__(mcls, name, bases, ns, **kwds)
+                assert mcls is not None
+                assert cls.method(mcls)
+                return cls
+            def method(cls, mcls):
+                return isinstance(cls, mcls)
+
         l = locals()
         exec("""class subclass_with_new(metaclass=metaclass_with_new):
             def __new__(cls):
@@ -234,10 +234,19 @@ def test_metaclass():
                 return self""", None, l)
         subclass_with_new = l['subclass_with_new']
     else:
+        class metaclass_with_new(type):
+            def __new__(mcls, name, bases, ns, **kwds):
+                cls = super(mcls, metaclass_with_new).__new__(mcls, name, bases, ns, **kwds)
+                assert mcls is not None
+                assert cls.method(mcls)
+                return cls
+            def method(cls, mcls):
+                return isinstance(cls, mcls)
+
         class subclass_with_new:
             __metaclass__ = metaclass_with_new
             def __new__(cls):
-                self = super().__new__(cls)
+                self = super(subclass_with_new, cls).__new__(cls)
                 return self
 
     assert dill.copy(subclass_with_new())


### PR DESCRIPTION
Follow up on https://github.com/uqfoundation/dill/pull/450#issuecomment-1120055277

The issue seems more limited in scope, only effecting metaclasses, not all classes. Still believe it is good to get it in before dill 0.3.5 is out.