### PR TITLE
enable support for develop and pep517

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,3 +20,9 @@ coverage:
         target: auto
         threshold: 1%
  
+fixes:
+  # reduces pip-installed path to git root and
+  # remove dist-name from setup-installed path
+  - "*/site-packages/::"
+  - "*/site-packages/dill-*::"
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,7 +15,8 @@ branch = true
 [paths]
 source =
     dill
-    */site-packages/dill*/dill
+    */site-packages/dill
+    */site-packages/dill-*/dill
 
 [report]
 include =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 # source = dill
-include = */dill/*
+include =
+    */dill/*
 omit = 
     */tests/*
     */info.py
@@ -11,7 +12,14 @@ branch = true
 # data_file = $TRAVIS_BUILD_DIR/.coverage
 # debug = trace
 
+[paths]
+source =
+    dill
+    */site-packages/dill*/dill
+
 [report]
+include =
+    */dill/*
 exclude_lines =
     pragma: no cover
     raise NotImplementedError

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
 
 # build
 python:
-  version: "3.7"
+  version: "3.9"
   install:
     - method: pip
       path: .

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
     - if [[ $NUMPY == "true" ]]; then pip install numpy; fi
 
 install:
-    - python setup.py build && python setup.py install
+    - python -m pip install .
 
 script:
     - for test in tests/__init__.py; do echo $test ; if [[ $COVERAGE == "true" ]]; then coverage run -a $test > /dev/null; else python $test > /dev/null; fi ; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ script:
 
 after_success:
     - if [[ $COVERAGE == "true" ]]; then bash <(curl -s https://codecov.io/bash); else echo ''; fi
+    - if [[ $COVERAGE == "true" ]]; then coverage report; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ matrix:
 
         - python: '3.7'
           env:
-            - COVERAGE="true"
-            - NUMPY="true"
 
         - python: '3.8'
           env:
 
         - python: '3.9'
           env:
+            - COVERAGE="true"
+            - NUMPY="true"
 
         - python: '3.10'
           env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include LICENSE
 include README*
+include MANIFEST.in
+include pyproject.toml
 include tox.ini
 include scripts/*
 include tests/*py

--- a/README.md
+++ b/README.md
@@ -83,6 +83,35 @@ You can get the latest development version with all the shiny new features at:
 If you have a new contribution, please submit a pull request.
 
 
+Installation
+------------
+``dill`` can be installed with ``pip``::
+
+    $ pip install dill
+
+To optionally include the ``objgraph`` diagnostic tool in the install::
+
+    $ pip install dill[graph]
+
+For windows users, to optionally install session history tools::
+
+    $ pip install dill[readline]
+
+
+Requirements
+------------
+``dill`` requires:
+
+* ``python`` (or ``pypy``), **==2.7** or **>=3.7**
+* ``setuptools``, **>=42**
+* ``wheel``, **>=0.1**
+
+Optional requirements:
+
+* ``objgraph``, **>=1.7.2**
+* ``pyreadline``, **>=1.7.1** (on windows)
+
+
 Basic Usage
 -----------
 ``dill`` is a drop-in replacement for ``pickle``. Existing code can be

--- a/dill/__init__.py
+++ b/dill/__init__.py
@@ -284,50 +284,46 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """
 
+from ._dill import dump, dumps, load, loads, dump_session, load_session, \
+    Pickler, Unpickler, register, copy, pickle, pickles, check, \
+    HIGHEST_PROTOCOL, DEFAULT_PROTOCOL, PicklingError, UnpicklingError, \
+    HANDLE_FMODE, CONTENTS_FMODE, FILE_FMODE, PickleError, PickleWarning, \
+    PicklingWarning, UnpicklingWarning
+from . import source, temp, detect
+
+# get global settings
+from .settings import settings
+
+# make sure "trace" is turned off
+detect.trace(False)
+
 try:
-    # This is a hack to import a minimal package for the build process
-    __DILL_SETUP__
-except NameError:
-    from ._dill import dump, dumps, load, loads, dump_session, load_session, \
-        Pickler, Unpickler, register, copy, pickle, pickles, check, \
-        HIGHEST_PROTOCOL, DEFAULT_PROTOCOL, PicklingError, UnpicklingError, \
-        HANDLE_FMODE, CONTENTS_FMODE, FILE_FMODE, PickleError, PickleWarning, \
-        PicklingWarning, UnpicklingWarning
-    from . import source, temp, detect
-
-    # get global settings
-    from .settings import settings
-
-    # make sure "trace" is turned off
-    detect.trace(False)
-
+    from importlib import reload
+except ImportError:
     try:
-        from importlib import reload
+        from imp import reload
     except ImportError:
-        try:
-            from imp import reload
-        except ImportError:
-            pass
+        pass
 
-    # put the objects in order, if possible
+# put the objects in order, if possible
+try:
+    from collections import OrderedDict as odict
+except ImportError:
     try:
-        from collections import OrderedDict as odict
+        from ordereddict import OrderedDict as odict
     except ImportError:
-        try:
-            from ordereddict import OrderedDict as odict
-        except ImportError:
-            odict = dict
-    objects = odict()
-    # local import of dill._objects
-    #from . import _objects
-    #objects.update(_objects.succeeds)
-    #del _objects
+        odict = dict
+objects = odict()
+# local import of dill._objects
+#from . import _objects
+#objects.update(_objects.succeeds)
+#del _objects
 
-    # local import of dill.objtypes
-    from . import objtypes as types
+# local import of dill.objtypes
+from . import objtypes as types
 
-    def load_types(pickleable=True, unpickleable=True):
-        """load pickleable and/or unpickleable types to ``dill.types``
+def load_types(pickleable=True, unpickleable=True):
+    """load pickleable and/or unpickleable types to ``dill.types``
 
     ``dill.types`` is meant to mimic the ``types`` module, providing a
     registry of object types.  By default, the module is empty (for import
@@ -341,26 +337,26 @@ except NameError:
     Returns:
         None
     """
-        # local import of dill.objects
-        from . import _objects
-        if pickleable:
-            objects.update(_objects.succeeds)
-        else:
-            [objects.pop(obj,None) for obj in _objects.succeeds]
-        if unpickleable:
-            objects.update(_objects.failures)
-        else:
-            [objects.pop(obj,None) for obj in _objects.failures]
-        objects.update(_objects.registered)
-        del _objects
-        # reset contents of types to 'empty'
-        [types.__dict__.pop(obj) for obj in list(types.__dict__.keys()) \
-                                 if obj.find('Type') != -1]
-        # add corresponding types from objects to types
-        reload(types)
+    # local import of dill.objects
+    from . import _objects
+    if pickleable:
+        objects.update(_objects.succeeds)
+    else:
+        [objects.pop(obj,None) for obj in _objects.succeeds]
+    if unpickleable:
+        objects.update(_objects.failures)
+    else:
+        [objects.pop(obj,None) for obj in _objects.failures]
+    objects.update(_objects.registered)
+    del _objects
+    # reset contents of types to 'empty'
+    [types.__dict__.pop(obj) for obj in list(types.__dict__.keys()) \
+                             if obj.find('Type') != -1]
+    # add corresponding types from objects to types
+    reload(types)
 
-    def extend(use_dill=True):
-        '''add (or remove) dill types to/from the pickle registry
+def extend(use_dill=True):
+    '''add (or remove) dill types to/from the pickle registry
 
     by default, ``dill`` populates its types to ``pickle.Pickler.dispatch``.
     Thus, all ``dill`` types are available upon calling ``'import pickle'``.
@@ -372,13 +368,13 @@ except NameError:
     Returns:
         None
     '''
-        from ._dill import _revert_extension, _extend
-        if use_dill: _extend()
-        else: _revert_extension()
-        return
+    from ._dill import _revert_extension, _extend
+    if use_dill: _extend()
+    else: _revert_extension()
+    return
 
-    extend()
-    del odict
+extend()
+del odict
 
 
 def license():

--- a/dill/__init__.py
+++ b/dill/__init__.py
@@ -6,62 +6,328 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/dill/blob/master/LICENSE
 
-# get version numbers, license, and long description
-try:
-    from .info import this_version as __version__
-    from .info import readme as __doc__, license as __license__
-except ImportError:
-    msg = """First run 'python setup.py build' to build dill."""
-    raise ImportError(msg)
-
+# author, version, license, and long description
+__version__ = '0.3.5.dev0'
 __author__ = 'Mike McKerns'
 
 __doc__ = """
-""" + __doc__
+-----------------------------
+dill: serialize all of python
+-----------------------------
+
+About Dill
+==========
+
+``dill`` extends python's ``pickle`` module for serializing and de-serializing
+python objects to the majority of the built-in python types. Serialization
+is the process of converting an object to a byte stream, and the inverse
+of which is converting a byte stream back to a python object hierarchy.
+
+``dill`` provides the user the same interface as the ``pickle`` module, and
+also includes some additional features. In addition to pickling python
+objects, ``dill`` provides the ability to save the state of an interpreter
+session in a single command.  Hence, it would be feasable to save an
+interpreter session, close the interpreter, ship the pickled file to
+another computer, open a new interpreter, unpickle the session and
+thus continue from the 'saved' state of the original interpreter
+session.
+
+``dill`` can be used to store python objects to a file, but the primary
+usage is to send python objects across the network as a byte stream.
+``dill`` is quite flexible, and allows arbitrary user defined classes
+and functions to be serialized.  Thus ``dill`` is not intended to be
+secure against erroneously or maliciously constructed data. It is
+left to the user to decide whether the data they unpickle is from
+a trustworthy source.
+
+``dill`` is part of ``pathos``, a python framework for heterogeneous computing.
+``dill`` is in active development, so any user feedback, bug reports, comments,
+or suggestions are highly appreciated.  A list of issues is located at https://github.com/uqfoundation/dill/issues, with a legacy list maintained at https://uqfoundation.github.io/project/pathos/query.
+
+
+Major Features
+==============
+
+``dill`` can pickle the following standard types:
+
+    - none, type, bool, int, long, float, complex, str, unicode,
+    - tuple, list, dict, file, buffer, builtin,
+    - both old and new style classes,
+    - instances of old and new style classes,
+    - set, frozenset, array, functions, exceptions
+
+``dill`` can also pickle more 'exotic' standard types:
+
+    - functions with yields, nested functions, lambdas,
+    - cell, method, unboundmethod, module, code, methodwrapper,
+    - dictproxy, methoddescriptor, getsetdescriptor, memberdescriptor,
+    - wrapperdescriptor, xrange, slice,
+    - notimplemented, ellipsis, quit
+
+``dill`` cannot yet pickle these standard types:
+
+    - frame, generator, traceback
+
+``dill`` also provides the capability to:
+
+    - save and load python interpreter sessions
+    - save and extract the source code from functions and classes
+    - interactively diagnose pickling errors
+
+
+Current Release
+===============
+
+The latest released version of ``dill`` is available from:
+
+    https://pypi.org/project/dill
+
+``dill`` is distributed under a 3-clause BSD license.
+
+
+Development Version
+===================
+
+You can get the latest development version with all the shiny new features at:
+
+    https://github.com/uqfoundation
+
+If you have a new contribution, please submit a pull request.
+
+
+Installation
+============
+
+``dill`` can be installed with ``pip``::
+
+    $ pip install dill
+
+To optionally include the ``objgraph`` diagnostic tool in the install::
+
+    $ pip install dill[graph]
+
+For windows users, to optionally install session history tools::
+
+    $ pip install dill[readline]
+
+
+Requirements
+============
+
+``dill`` requires:
+
+    - ``python`` (or ``pypy``), **==2.7** or **>=3.7**
+    - ``setuptools``, **>=42**
+    - ``wheel``, **>=0.1**
+
+Optional requirements:
+
+    - ``objgraph``, **>=1.7.2**
+    - ``pyreadline``, **>=1.7.1** (on windows)
+
+
+Basic Usage
+===========
+
+``dill`` is a drop-in replacement for ``pickle``. Existing code can be
+updated to allow complete pickling using::
+
+    >>> import dill as pickle
+
+or::
+
+    >>> from dill import dumps, loads
+
+``dumps`` converts the object to a unique byte string, and ``loads`` performs
+the inverse operation::
+
+    >>> squared = lambda x: x**2
+    >>> loads(dumps(squared))(3)
+    9
+
+There are a number of options to control serialization which are provided
+as keyword arguments to several ``dill`` functions:
+
+* with *protocol*, the pickle protocol level can be set. This uses the
+  same value as the ``pickle`` module, *HIGHEST_PROTOCOL* or *DEFAULT_PROTOCOL*.
+* with *byref=True*, ``dill`` to behave a lot more like pickle with
+  certain objects (like modules) pickled by reference as opposed to
+  attempting to pickle the object itself.
+* with *recurse=True*, objects referred to in the global dictionary are
+  recursively traced and pickled, instead of the default behavior of
+  attempting to store the entire global dictionary.
+* with *fmode*, the contents of the file can be pickled along with the file
+  handle, which is useful if the object is being sent over the wire to a
+  remote system which does not have the original file on disk. Options are
+  *HANDLE_FMODE* for just the handle, *CONTENTS_FMODE* for the file content
+  and *FILE_FMODE* for content and handle.
+* with *ignore=False*, objects reconstructed with types defined in the
+  top-level script environment use the existing type in the environment
+  rather than a possibly different reconstructed type.
+
+The default serialization can also be set globally in *dill.settings*.
+Thus, we can modify how ``dill`` handles references to the global dictionary
+locally or globally::
+
+    >>> import dill.settings
+    >>> dumps(absolute) == dumps(absolute, recurse=True)
+    False
+    >>> dill.settings['recurse'] = True
+    >>> dumps(absolute) == dumps(absolute, recurse=True)
+    True
+
+``dill`` also includes source code inspection, as an alternate to pickling::
+
+    >>> import dill.source
+    >>> print(dill.source.getsource(squared))
+    squared = lambda x:x**2
+
+To aid in debugging pickling issues, use *dill.detect* which provides
+tools like pickle tracing::
+
+    >>> import dill.detect
+    >>> dill.detect.trace(True)
+    >>> f = dumps(squared)
+    F1: <function <lambda> at 0x108899e18>
+    F2: <function _create_function at 0x108db7488>
+    # F2
+    Co: <code object <lambda> at 0x10866a270, file "<stdin>", line 1>
+    F2: <function _create_code at 0x108db7510>
+    # F2
+    # Co
+    D1: <dict object at 0x10862b3f0>
+    # D1
+    D2: <dict object at 0x108e42ee8>
+    # D2
+    # F1
+    >>> dill.detect.trace(False)
+
+With trace, we see how ``dill`` stored the lambda (``F1``) by first storing
+``_create_function``, the underlying code object (``Co``) and ``_create_code``
+(which is used to handle code objects), then we handle the reference to
+the global dict (``D2``).  A ``#`` marks when the object is actually stored.
+
+
+More Information
+================
+
+Probably the best way to get started is to look at the documentation at
+http://dill.rtfd.io. Also see ``dill.tests`` for a set of scripts that
+demonstrate how ``dill`` can serialize different python objects. You can
+run the test suite with ``python -m dill.tests``. The contents of any
+pickle file can be examined with ``undill``.  As ``dill`` conforms to
+the ``pickle`` interface, the examples and documentation found at
+http://docs.python.org/library/pickle.html also apply to ``dill``
+if one will ``import dill as pickle``. The source code is also generally
+well documented, so further questions may be resolved by inspecting the
+code itself. Please feel free to submit a ticket on github, or ask a
+question on stackoverflow (**@Mike McKerns**).
+If you would like to share how you use ``dill`` in your work, please send
+an email (to **mmckerns at uqfoundation dot org**).
+
+
+Citation
+========
+
+If you use ``dill`` to do research that leads to publication, we ask that you
+acknowledge use of ``dill`` by citing the following in your publication::
+
+    M.M. McKerns, L. Strand, T. Sullivan, A. Fang, M.A.G. Aivazis,
+    "Building a framework for predictive science", Proceedings of
+    the 10th Python in Science Conference, 2011;
+    http://arxiv.org/pdf/1202.1056
+
+    Michael McKerns and Michael Aivazis,
+    "pathos: a framework for heterogeneous computing", 2010- ;
+    https://uqfoundation.github.io/project/pathos
+
+Please see https://uqfoundation.github.io/project/pathos or
+http://arxiv.org/pdf/1202.1056 for further information.
+
+"""
 
 __license__ = """
-""" + __license__
+Copyright (c) 2004-2016 California Institute of Technology.
+Copyright (c) 2016-2022 The Uncertainty Quantification Foundation.
+All rights reserved.
 
-from ._dill import dump, dumps, load, loads, dump_session, load_session, \
-    Pickler, Unpickler, register, copy, pickle, pickles, check, \
-    HIGHEST_PROTOCOL, DEFAULT_PROTOCOL, PicklingError, UnpicklingError, \
-    HANDLE_FMODE, CONTENTS_FMODE, FILE_FMODE, PickleError, PickleWarning, \
-    PicklingWarning, UnpicklingWarning
-from . import source, temp, detect
+This software is available subject to the conditions and terms laid
+out below. By downloading and using this software you are agreeing
+to the following conditions.
 
-# get global settings
-from .settings import settings
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met::
 
-# make sure "trace" is turned off
-detect.trace(False)
+    - Redistribution of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistribution in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentations and/or other materials provided with the distribution.
+
+    - Neither the names of the copyright holders nor the names of any of
+      the contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
 
 try:
-    from importlib import reload
-except ImportError:
+    # This is a hack to import a minimal package for the build process
+    __DILL_SETUP__
+except NameError:
+    from ._dill import dump, dumps, load, loads, dump_session, load_session, \
+        Pickler, Unpickler, register, copy, pickle, pickles, check, \
+        HIGHEST_PROTOCOL, DEFAULT_PROTOCOL, PicklingError, UnpicklingError, \
+        HANDLE_FMODE, CONTENTS_FMODE, FILE_FMODE, PickleError, PickleWarning, \
+        PicklingWarning, UnpicklingWarning
+    from . import source, temp, detect
+
+    # get global settings
+    from .settings import settings
+
+    # make sure "trace" is turned off
+    detect.trace(False)
+
     try:
-        from imp import reload
+        from importlib import reload
     except ImportError:
-        pass
+        try:
+            from imp import reload
+        except ImportError:
+            pass
 
-# put the objects in order, if possible
-try:
-    from collections import OrderedDict as odict
-except ImportError:
+    # put the objects in order, if possible
     try:
-        from ordereddict import OrderedDict as odict
+        from collections import OrderedDict as odict
     except ImportError:
-        odict = dict
-objects = odict()
-# local import of dill._objects
-#from . import _objects
-#objects.update(_objects.succeeds)
-#del _objects
+        try:
+            from ordereddict import OrderedDict as odict
+        except ImportError:
+            odict = dict
+    objects = odict()
+    # local import of dill._objects
+    #from . import _objects
+    #objects.update(_objects.succeeds)
+    #del _objects
 
-# local import of dill.objtypes
-from . import objtypes as types
+    # local import of dill.objtypes
+    from . import objtypes as types
 
-def load_types(pickleable=True, unpickleable=True):
-    """load pickleable and/or unpickleable types to ``dill.types``
+    def load_types(pickleable=True, unpickleable=True):
+        """load pickleable and/or unpickleable types to ``dill.types``
 
     ``dill.types`` is meant to mimic the ``types`` module, providing a
     registry of object types.  By default, the module is empty (for import
@@ -75,26 +341,26 @@ def load_types(pickleable=True, unpickleable=True):
     Returns:
         None
     """
-    # local import of dill.objects
-    from . import _objects
-    if pickleable:
-        objects.update(_objects.succeeds)
-    else:
-        [objects.pop(obj,None) for obj in _objects.succeeds]
-    if unpickleable:
-        objects.update(_objects.failures)
-    else:
-        [objects.pop(obj,None) for obj in _objects.failures]
-    objects.update(_objects.registered)
-    del _objects
-    # reset contents of types to 'empty'
-    [types.__dict__.pop(obj) for obj in list(types.__dict__.keys()) \
-                             if obj.find('Type') != -1]
-    # add corresponding types from objects to types
-    reload(types)
+        # local import of dill.objects
+        from . import _objects
+        if pickleable:
+            objects.update(_objects.succeeds)
+        else:
+            [objects.pop(obj,None) for obj in _objects.succeeds]
+        if unpickleable:
+            objects.update(_objects.failures)
+        else:
+            [objects.pop(obj,None) for obj in _objects.failures]
+        objects.update(_objects.registered)
+        del _objects
+        # reset contents of types to 'empty'
+        [types.__dict__.pop(obj) for obj in list(types.__dict__.keys()) \
+                                 if obj.find('Type') != -1]
+        # add corresponding types from objects to types
+        reload(types)
 
-def extend(use_dill=True):
-    '''add (or remove) dill types to/from the pickle registry
+    def extend(use_dill=True):
+        '''add (or remove) dill types to/from the pickle registry
 
     by default, ``dill`` populates its types to ``pickle.Pickler.dispatch``.
     Thus, all ``dill`` types are available upon calling ``'import pickle'``.
@@ -106,12 +372,14 @@ def extend(use_dill=True):
     Returns:
         None
     '''
-    from ._dill import _revert_extension, _extend
-    if use_dill: _extend()
-    else: _revert_extension()
-    return
+        from ._dill import _revert_extension, _extend
+        if use_dill: _extend()
+        else: _revert_extension()
+        return
 
-extend()
+    extend()
+    del odict
+
 
 def license():
     """print license"""
@@ -122,7 +390,5 @@ def citation():
     """print citation"""
     print (__doc__[-491:-118])
     return
-
-del odict
 
 # end of file

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,5 +24,5 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)
 	-rm -f $(BUILDDIR)/../../scripts/_*py
 	-rm -f $(BUILDDIR)/../../scripts/_*pyc
-	-rm -f $(BUILDDIR)/../../scripts/__pycache__
+	-rm -rf $(BUILDDIR)/../../scripts/__pycache__
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,4 +24,5 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)
 	-rm -f $(BUILDDIR)/../../scripts/_*py
 	-rm -f $(BUILDDIR)/../../scripts/_*pyc
+	-rm -f $(BUILDDIR)/../../scripts/__pycache__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+# Further build requirements come from setup.py via the PEP 517 interface
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,7 @@
 [egg_info]
 tag_build = .dev0
-#tag_svn_revision = yes
-#tag_date = yes
+
+[bdist_wheel]
+#universal = 1
+#python-tag = py3
+#plat-name = manylinux1_x86_64

--- a/setup.py
+++ b/setup.py
@@ -17,383 +17,108 @@ elif (3, 0) <= sys.version_info < (3, 7):
 if unsupported:
     raise ValueError(unsupported)
 
-# set version numbers
-stable_version = '0.3.4'
-target_version = '0.3.5'
-is_release = stable_version == target_version
-
-# check if easy_install is available
 try:
-#   import __force_distutils__ #XXX: uncomment to force use of distutills
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+
+# This is a hack to import a minimal package for the build process
+builtins.__DILL_SETUP__ = True
+sys.path.append(os.path.abspath(os.path.curdir))
+import dill
+
+# get version numbers, long_description, etc
+AUTHOR = dill.__author__
+VERSION = dill.__version__
+LONG_DOC = dill.__doc__ #FIXME: near-duplicate of README.md
+#LICENSE = dill.__license__ #FIXME: duplicate of LICENSE
+AUTHOR_EMAIL = 'mmckerns@uqfoundation.org'
+
+# check if setuptools is available
+try:
     from setuptools import setup
+    from setuptools.dist import Distribution
     has_setuptools = True
 except ImportError:
     from distutils.core import setup
+    Distribution = object
     has_setuptools = False
 
-# generate version number
-if os.path.exists('dill/info.py'):
-    # is a source distribution, so use existing version
-    os.chdir('dill')
-    with open('info.py','r') as f:
-        f.readline() # header
-        this_version = f.readline().split()[-1].strip("'")
-    os.chdir('..')
-elif stable_version == target_version:
-    # we are building a stable release
-    this_version = target_version
-else:
-    # we are building a distribution
-    this_version = target_version + '.dev0'
-    if is_release:
-        from datetime import date
-        today = "".join(date.isoformat(date.today()).split('-'))
-        this_version += "-" + today
-
-# get the license info
-with open('LICENSE') as file:
-    license_text = file.read()
-
-# generate the readme text
-long_description = \
-"""-----------------------------
-dill: serialize all of python
------------------------------
-
-About Dill
-==========
-
-``dill`` extends python's ``pickle`` module for serializing and de-serializing
-python objects to the majority of the built-in python types. Serialization
-is the process of converting an object to a byte stream, and the inverse
-of which is converting a byte stream back to a python object hierarchy.
-
-``dill`` provides the user the same interface as the ``pickle`` module, and
-also includes some additional features. In addition to pickling python
-objects, ``dill`` provides the ability to save the state of an interpreter
-session in a single command.  Hence, it would be feasable to save an
-interpreter session, close the interpreter, ship the pickled file to
-another computer, open a new interpreter, unpickle the session and
-thus continue from the 'saved' state of the original interpreter
-session.
-
-``dill`` can be used to store python objects to a file, but the primary
-usage is to send python objects across the network as a byte stream.
-``dill`` is quite flexible, and allows arbitrary user defined classes
-and functions to be serialized.  Thus ``dill`` is not intended to be
-secure against erroneously or maliciously constructed data. It is
-left to the user to decide whether the data they unpickle is from
-a trustworthy source.
-
-``dill`` is part of ``pathos``, a python framework for heterogeneous computing.
-``dill`` is in active development, so any user feedback, bug reports, comments,
-or suggestions are highly appreciated.  A list of issues is located at https://github.com/uqfoundation/dill/issues, with a legacy list maintained at https://uqfoundation.github.io/project/pathos/query.
-
-
-Major Features
-==============
-
-``dill`` can pickle the following standard types:
-
-    - none, type, bool, int, long, float, complex, str, unicode,
-    - tuple, list, dict, file, buffer, builtin,
-    - both old and new style classes,
-    - instances of old and new style classes,
-    - set, frozenset, array, functions, exceptions
-
-``dill`` can also pickle more 'exotic' standard types:
-
-    - functions with yields, nested functions, lambdas,
-    - cell, method, unboundmethod, module, code, methodwrapper,
-    - dictproxy, methoddescriptor, getsetdescriptor, memberdescriptor,
-    - wrapperdescriptor, xrange, slice,
-    - notimplemented, ellipsis, quit
-
-``dill`` cannot yet pickle these standard types:
-
-    - frame, generator, traceback
-
-``dill`` also provides the capability to:
-
-    - save and load python interpreter sessions
-    - save and extract the source code from functions and classes
-    - interactively diagnose pickling errors
-
-
-Current Release
-===============
-
-This documentation is for version ``dill-%(thisver)s``.
-
-The latest released version of ``dill`` is available from:
-
-    https://pypi.org/project/dill
-
-``dill`` is distributed under a 3-clause BSD license.
-
-    >>> import dill
-    >>> dill.license()
-
-
-Development Version
-===================
-
-You can get the latest development version with all the shiny new features at:
-
-    https://github.com/uqfoundation
-
-If you have a new contribution, please submit a pull request.
-
-
-Installation
-============
-
-``dill`` is packaged to install from source, so you must
-download the tarball, unzip, and run the installer::
-
-    [download]
-    $ tar -xvzf dill-%(relver)s.tar.gz
-    $ cd dill-%(relver)s
-    $ python setup py build
-    $ python setup py install
-
-You will be warned of any missing dependencies and/or settings
-after you run the "build" step above.
-
-Alternately, ``dill`` can be installed with ``pip`` or ``easy_install``::
-
-    $ pip install dill
-
-
-Requirements
-============
-
-``dill`` requires:
-
-    - ``python`` (or ``pypy``), **version == 2.7** or **version >= 3.7**
-
-Optional requirements:
-
-    - ``setuptools``, **version >= 40.6.0**
-    - ``pyreadline``, **version >= 1.7.1** (on windows)
-    - ``objgraph``, **version >= 1.7.2**
-
-
-Basic Usage
-===========
-
-``dill`` is a drop-in replacement for ``pickle``. Existing code can be
-updated to allow complete pickling using::
-
-    >>> import dill as pickle
-
-or::
-
-    >>> from dill import dumps, loads
-
-``dumps`` converts the object to a unique byte string, and ``loads`` performs
-the inverse operation::
-
-    >>> squared = lambda x: x**2
-    >>> loads(dumps(squared))(3)
-    9
-
-There are a number of options to control serialization which are provided
-as keyword arguments to several ``dill`` functions:
-
-* with *protocol*, the pickle protocol level can be set. This uses the
-  same value as the ``pickle`` module, *HIGHEST_PROTOCOL* or *DEFAULT_PROTOCOL*.
-* with *byref=True*, ``dill`` to behave a lot more like pickle with
-  certain objects (like modules) pickled by reference as opposed to
-  attempting to pickle the object itself.
-* with *recurse=True*, objects referred to in the global dictionary are
-  recursively traced and pickled, instead of the default behavior of
-  attempting to store the entire global dictionary.
-* with *fmode*, the contents of the file can be pickled along with the file
-  handle, which is useful if the object is being sent over the wire to a
-  remote system which does not have the original file on disk. Options are
-  *HANDLE_FMODE* for just the handle, *CONTENTS_FMODE* for the file content
-  and *FILE_FMODE* for content and handle.
-* with *ignore=False*, objects reconstructed with types defined in the
-  top-level script environment use the existing type in the environment
-  rather than a possibly different reconstructed type.
-
-The default serialization can also be set globally in *dill.settings*.
-Thus, we can modify how ``dill`` handles references to the global dictionary
-locally or globally::
-
-    >>> import dill.settings
-    >>> dumps(absolute) == dumps(absolute, recurse=True)
-    False
-    >>> dill.settings['recurse'] = True
-    >>> dumps(absolute) == dumps(absolute, recurse=True)
-    True
-
-``dill`` also includes source code inspection, as an alternate to pickling::
-
-    >>> import dill.source
-    >>> print(dill.source.getsource(squared))
-    squared = lambda x:x**2
-
-To aid in debugging pickling issues, use *dill.detect* which provides
-tools like pickle tracing::
-
-    >>> import dill.detect
-    >>> dill.detect.trace(True)
-    >>> f = dumps(squared)
-    F1: <function <lambda> at 0x108899e18>
-    F2: <function _create_function at 0x108db7488>
-    # F2
-    Co: <code object <lambda> at 0x10866a270, file "<stdin>", line 1>
-    F2: <function _create_code at 0x108db7510>
-    # F2
-    # Co
-    D1: <dict object at 0x10862b3f0>
-    # D1
-    D2: <dict object at 0x108e42ee8>
-    # D2
-    # F1
-    >>> dill.detect.trace(False)
-
-With trace, we see how ``dill`` stored the lambda (``F1``) by first storing
-``_create_function``, the underlying code object (``Co``) and ``_create_code``
-(which is used to handle code objects), then we handle the reference to
-the global dict (``D2``).  A ``#`` marks when the object is actually stored.
-
-
-More Information
-================
-
-Probably the best way to get started is to look at the documentation at
-http://dill.rtfd.io. Also see ``dill.tests`` for a set of scripts that
-demonstrate how ``dill`` can serialize different python objects. You can
-run the test suite with ``python -m dill.tests``. The contents of any
-pickle file can be examined with ``undill``.  As ``dill`` conforms to
-the ``pickle`` interface, the examples and documentation found at
-http://docs.python.org/library/pickle.html also apply to ``dill``
-if one will ``import dill as pickle``. The source code is also generally
-well documented, so further questions may be resolved by inspecting the
-code itself. Please feel free to submit a ticket on github, or ask a
-question on stackoverflow (**@Mike McKerns**).
-If you would like to share how you use ``dill`` in your work, please send
-an email (to **mmckerns at uqfoundation dot org**).
-
-
-Citation
-========
-
-If you use ``dill`` to do research that leads to publication, we ask that you
-acknowledge use of ``dill`` by citing the following in your publication::
-
-    M.M. McKerns, L. Strand, T. Sullivan, A. Fang, M.A.G. Aivazis,
-    "Building a framework for predictive science", Proceedings of
-    the 10th Python in Science Conference, 2011;
-    http://arxiv.org/pdf/1202.1056
-
-    Michael McKerns and Michael Aivazis,
-    "pathos: a framework for heterogeneous computing", 2010- ;
-    https://uqfoundation.github.io/project/pathos
-
-Please see https://uqfoundation.github.io/project/pathos or
-http://arxiv.org/pdf/1202.1056 for further information.
-
-""" % {'relver' : stable_version, 'thisver' : this_version}
-
-# write readme file
-with open('README', 'w') as file:
-    file.write(long_description)
-
-# generate 'info' file contents
-def write_info_py(filename='dill/info.py'):
-    contents = """# THIS FILE GENERATED FROM SETUP.PY
-this_version = '%(this_version)s'
-stable_version = '%(stable_version)s'
-readme = '''%(long_description)s'''
-license = '''%(license_text)s'''
-"""
-    with open(filename, 'w') as file:
-        file.write(contents % {'this_version' : this_version,
-                               'stable_version' : stable_version,
-                               'long_description' : long_description,
-                               'license_text' : license_text })
-    return
-
-# write info file
-write_info_py()
-
 # build the 'setup' call
-setup_code = """
-setup(name='dill',
-      version='%s',
-      description='serialize all of python',
-      long_description = '''%s''',
-      author = 'Mike McKerns',
-      maintainer = 'Mike McKerns',
-      license = '3-clause BSD',
-      platforms = ['Linux', 'Windows', 'Mac'],
-      url = 'https://github.com/uqfoundation/dill',
-      download_url = 'https://github.com/uqfoundation/dill/releases/download/dill-%s/dill-%s.tar.gz',
-      python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*',
-      classifiers = ['Development Status :: 5 - Production/Stable',
-                     'Intended Audience :: Developers',
-                     'Intended Audience :: Science/Research',
-                     'License :: OSI Approved :: BSD License',
-                     'Programming Language :: Python :: 2',
-                     'Programming Language :: Python :: 2.7',
-                     'Programming Language :: Python :: 3',
-                     'Programming Language :: Python :: 3.7',
-                     'Programming Language :: Python :: 3.8',
-                     'Programming Language :: Python :: 3.9',
-                     'Programming Language :: Python :: 3.10',
-                     'Programming Language :: Python :: Implementation :: PyPy',
-                     'Topic :: Scientific/Engineering',
-                     'Topic :: Software Development'],
+setup_kwds = dict(
+    name='dill',
+    version=VERSION,
+    description='serialize all of python',
+    long_description = LONG_DOC,
+    author = AUTHOR,
+    author_email = AUTHOR_EMAIL,
+    maintainer = AUTHOR,
+    maintainer_email = AUTHOR_EMAIL,
+    license = '3-clause BSD',
+    platforms = ['Linux', 'Windows', 'Mac'],
+    url = 'https://github.com/uqfoundation/dill',
+    download_url = 'https://pypi.org/project/dill/#files',
+    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*',
+    classifiers = ['Development Status :: 5 - Production/Stable',
+                   'Intended Audience :: Developers',
+                   'Intended Audience :: Science/Research',
+                   'License :: OSI Approved :: BSD License',
+                   'Programming Language :: Python :: 2',
+                   'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3',
+                   'Programming Language :: Python :: 3.7',
+                   'Programming Language :: Python :: 3.8',
+                   'Programming Language :: Python :: 3.9',
+                   'Programming Language :: Python :: 3.10',
+                   'Programming Language :: Python :: Implementation :: PyPy',
+                   'Topic :: Scientific/Engineering',
+                   'Topic :: Software Development'],
+    packages = ['dill','dill.tests'],
+    package_dir = {'dill':'dill', 'dill.tests':'tests'},
+    scripts=['scripts/undill','scripts/get_objgraph'],
+)
 
-      packages = ['dill','dill.tests'],
-      package_dir = {'dill':'dill', 'dill.tests':'tests'},
-""" % (target_version, long_description, stable_version, stable_version)
+# force python-, abi-, and platform-specific naming of bdist_wheel
+class BinaryDistribution(Distribution):
+    """Distribution which forces a binary package with platform name"""
+    def has_ext_modules(foo):
+        return True
 
+# define dependencies
+ctypes_version = 'ctypes>=1.0.1'
+objgraph_version = 'objgraph>=1.7.2'
+pyreadline_version = 'pyreadline>=1.7.1'
 # add dependencies
-ctypes_version = '>=1.0.1'
-objgraph_version = '>=1.7.2'
-pyreadline_version = '>=1.7.1'
+depend = [ctypes_version]
+if sys.platform[:3] == 'win':
+    extras = {'readline': [pyreadline_version], 'graph': [objgraph_version]}
+else:
+    extras = {'readline': [], 'graph': [objgraph_version]}
+# update setup kwds
 if has_setuptools:
-    setup_code += """
-      zip_safe=False,
-"""
-    if sys.platform[:3] == 'win':
-        setup_code += """
-      extras_require = {'readline': ['pyreadline%s'], 'graph': ['objgraph%s']},
-""" % (pyreadline_version, objgraph_version)
-    # verrrry unlikely that this is still relevant
-    elif hex(sys.hexversion) < '0x20500f0':
-        setup_code += """
-      install_requires = ['ctypes%s'],
-      extras_require = {'readline': [], 'graph': ['objgraph%s']},
-""" % (ctypes_version, objgraph_version)
-    else:
-        setup_code += """
-      extras_require = {'readline': [], 'graph': ['objgraph%s']},
-""" % (objgraph_version)
+    setup_kwds.update(
+        zip_safe=False,
+        # distclass=BinaryDistribution,
+        # install_requires=depend,
+        extras_require=extras,
+    )
 
-# add the scripts, and close 'setup' call
-setup_code += """    
-      scripts=['scripts/undill','scripts/get_objgraph'])
-"""
-
-# exec the 'setup' code
-exec(setup_code)
+# call setup
+setup(**setup_kwds)
 
 # if dependencies are missing, print a warning
 try:
-    import ctypes
-    import readline
+    pass
+    #import ctypes
+    #import objgraph
+    #import readline
 except ImportError:
     print ("\n***********************************************************")
     print ("WARNING: One of the following dependencies is unresolved:")
-    print ("    ctypes %s" % ctypes_version)
+#   print ("    %s" % ctypes_version)
+    print ("    %s (optional)" % objgraph_version)
     if sys.platform[:3] == 'win':
-        print ("    readline %s" % pyreadline_version)
+        print ("    %s (optional)" % pyreadline_version)
     print ("***********************************************************\n")
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,21 +17,42 @@ elif (3, 0) <= sys.version_info < (3, 7):
 if unsupported:
     raise ValueError(unsupported)
 
+# get distribution meta info
+here = os.path.abspath(os.path.dirname(__file__))
+meta_fh = open(os.path.join(here, 'dill/__init__.py'))
 try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
-
-# This is a hack to import a minimal package for the build process
-builtins.__DILL_SETUP__ = True
-sys.path.append(os.path.abspath(os.path.curdir))
-import dill
+    meta = {}
+    for line in meta_fh:
+        if line.startswith('__version__'):
+            VERSION = line.split()[-1].strip("'").strip('"')
+            break
+    meta['VERSION'] = VERSION
+    for line in meta_fh:
+        if line.startswith('__author__'):
+            AUTHOR = line.split(' = ')[-1].strip().strip("'").strip('"')
+            break
+    meta['AUTHOR'] = AUTHOR
+    LONG_DOC = ""
+    DOC_STOP = "FAKE_STOP_12345"
+    for line in meta_fh:
+        if LONG_DOC:
+            if line.startswith(DOC_STOP):
+                LONG_DOC += DOC_STOP.rstrip()
+                break
+            else:
+                LONG_DOC += line
+        elif line.startswith('__doc__'):
+            DOC_STOP = line.split(' = ')[-1]
+            LONG_DOC += DOC_STOP
+    meta['LONG_DOC'] = LONG_DOC
+finally:
+    meta_fh.close()
 
 # get version numbers, long_description, etc
-AUTHOR = dill.__author__
-VERSION = dill.__version__
-LONG_DOC = dill.__doc__ #FIXME: near-duplicate of README.md
-#LICENSE = dill.__license__ #FIXME: duplicate of LICENSE
+AUTHOR = meta['AUTHOR']
+VERSION = meta['VERSION']
+LONG_DOC = meta['LONG_DOC'] #FIXME: near-duplicate of README.md
+#LICENSE = meta['LICENSE'] #FIXME: duplicate of LICENSE
 AUTHOR_EMAIL = 'mmckerns@uqfoundation.org'
 
 # check if setuptools is available

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -28,7 +28,7 @@ def test_bad_things():
     assert list(errors(f, 1).keys()) == list(d.keys())
     s = set([(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())])
     a = dict(s)
-    if os.environ.get('TRAVIS_PYTHON_VERSION'): #XXX: travis-ci
+    if os.environ.get('COVERAGE_RUN'): #XXX: travis-ci
         assert len(s) is len(a) # TypeError (and possibly PicklingError)
     n = 1 if IS_PYPY2 else 2
     assert len(a) is n if 'PicklingError' in a.keys() else n-1

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -27,7 +27,10 @@ def test_bad_things():
     assert list(errors(f, 1).keys()) == list(d.keys())
     s = set([(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())])
     a = dict(s)
-    if 0x30700f0 <= sys.hexversion > 0x30709f0: #XXX: travis-ci
+    if (0x30700a0 >= sys.hexversion or
+        0x30800a0 >= sys.hexversion > 0x30709f0 or
+        0x30900a0 >= sys.hexversion > 0x30809f0 or
+        0x31000a0 >= sys.hexversion > 0x30909f0): #XXX: travis-ci
         assert len(s) is len(a) # TypeError (and possibly PicklingError)
     n = 1 if IS_PYPY2 else 2
     assert len(a) is n if 'PicklingError' in a.keys() else n-1

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -13,6 +13,7 @@ from pickle import PicklingError
 
 import inspect
 import sys
+import os
 
 def test_bad_things():
     f = inspect.currentframe()
@@ -27,10 +28,7 @@ def test_bad_things():
     assert list(errors(f, 1).keys()) == list(d.keys())
     s = set([(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())])
     a = dict(s)
-    if (0x30700a0 >= sys.hexversion or
-        0x30800a0 >= sys.hexversion > 0x30709f0 or
-        0x30900a0 >= sys.hexversion > 0x30809f0 or
-        0x31000a0 >= sys.hexversion > 0x30909f0): #XXX: travis-ci
+    if os.environ.get('TRAVIS_PYTHON_VERSION'): #XXX: travis-ci
         assert len(s) is len(a) # TypeError (and possibly PicklingError)
     n = 1 if IS_PYPY2 else 2
     assert len(a) is n if 'PicklingError' in a.keys() else n-1

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -28,7 +28,7 @@ def test_bad_things():
     assert list(errors(f, 1).keys()) == list(d.keys())
     s = set([(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())])
     a = dict(s)
-    if os.environ.get('COVERAGE_RUN'): #XXX: travis-ci
+    if not os.environ.get('COVERAGE'): #XXX: travis-ci
         assert len(s) is len(a) # TypeError (and possibly PicklingError)
     n = 1 if IS_PYPY2 else 2
     assert len(a) is n if 'PicklingError' in a.keys() else n-1

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps =
 whitelist_externals =
     bash
 commands =
-    {envpython} setup.py build
-    {envpython} setup.py install
+    {envpython} -m pip install .
     bash -c "failed=0; for test in tests/__main__.py; do echo $test; \
              {envpython} $test || failed=1; done; exit $failed"


### PR DESCRIPTION
remove `exec` from build in setup.py; enable support for in-place builds and pep517-compliant builds

Fixes #431 