### PR TITLE
Add detailed trace mode showing saved object size and visual depth level

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,26 +170,30 @@ To aid in debugging pickling issues, use *dill.detect* which provides
 tools like pickle tracing::
 
     >>> import dill.detect
-    >>> dill.detect.trace(True)
-    >>> f = dumps(squared)
-    F1: <function <lambda> at 0x108899e18>
-    F2: <function _create_function at 0x108db7488>
-    # F2
-    Co: <code object <lambda> at 0x10866a270, file "<stdin>", line 1>
-    F2: <function _create_code at 0x108db7510>
-    # F2
-    # Co
-    D1: <dict object at 0x10862b3f0>
-    # D1
-    D2: <dict object at 0x108e42ee8>
-    # D2
-    # F1
-    >>> dill.detect.trace(False)
+    >>> with dill.detect.trace():
+    >>>     dumps(squared)
+    ┬ F1: <function <lambda> at 0x7fe074f8c280>
+    ├┬ F2: <function _create_function at 0x7fe074c49c10>
+    │└ # F2 [34 B]
+    ├┬ Co: <code object <lambda> at 0x7fe07501eb30, file "<stdin>", line 1>
+    │├┬ F2: <function _create_code at 0x7fe074c49ca0>
+    ││└ # F2 [19 B]
+    │└ # Co [87 B]
+    ├┬ D1: <dict object at 0x7fe0750d4680>
+    │└ # D1 [22 B]
+    ├┬ D2: <dict object at 0x7fe074c5a1c0>
+    │└ # D2 [2 B]
+    ├┬ D2: <dict object at 0x7fe074f903c0>
+    │├┬ D2: <dict object at 0x7fe074f8ebc0>
+    ││└ # D2 [2 B]
+    │└ # D2 [23 B]
+    └ # F1 [180 B]
 
 With trace, we see how ``dill`` stored the lambda (``F1``) by first storing
 ``_create_function``, the underlying code object (``Co``) and ``_create_code``
 (which is used to handle code objects), then we handle the reference to
-the global dict (``D2``).  A ``#`` marks when the object is actually stored.
+the global dict (``D2``) plus other dictionaries (``D1`` and ``D2``) that
+save the lambda object's state. A ``#`` marks when the object is actually stored.
 
 
 More Information

--- a/dill/__init__.py
+++ b/dill/__init__.py
@@ -187,18 +187,22 @@ tools like pickle tracing::
     >>> import dill.detect
     >>> dill.detect.trace(True)
     >>> f = dumps(squared)
-    F1: <function <lambda> at 0x108899e18>
-    F2: <function _create_function at 0x108db7488>
-    # F2
-    Co: <code object <lambda> at 0x10866a270, file "<stdin>", line 1>
-    F2: <function _create_code at 0x108db7510>
-    # F2
-    # Co
-    D1: <dict object at 0x10862b3f0>
-    # D1
-    D2: <dict object at 0x108e42ee8>
-    # D2
-    # F1
+    ┬ F1: <function <lambda> at 0x7fe074f8c280>
+    ├┬ F2: <function _create_function at 0x7fe074c49c10>
+    │└ # F2 [34 B]
+    ├┬ Co: <code object <lambda> at 0x7fe07501eb30, file "<stdin>", line 1>
+    │├┬ F2: <function _create_code at 0x7fe074c49ca0>
+    ││└ # F2 [19 B]
+    │└ # Co [87 B]
+    ├┬ D1: <dict object at 0x7fe0750d4680>
+    │└ # D1 [22 B]
+    ├┬ D2: <dict object at 0x7fe074c5a1c0>
+    │└ # D2 [2 B]
+    ├┬ D2: <dict object at 0x7fe074f903c0>
+    │├┬ D2: <dict object at 0x7fe074f8ebc0>
+    ││└ # D2 [2 B]
+    │└ # D2 [23 B]
+    └ # F1 [180 B]
     >>> dill.detect.trace(False)
 
 With trace, we see how ``dill`` stored the lambda (``F1``) by first storing

--- a/dill/__init__.py
+++ b/dill/__init__.py
@@ -185,8 +185,8 @@ To aid in debugging pickling issues, use *dill.detect* which provides
 tools like pickle tracing::
 
     >>> import dill.detect
-    >>> dill.detect.trace(True)
-    >>> f = dumps(squared)
+    >>> with dill.detect.trace():
+    >>>     dumps(squared)
     ┬ F1: <function <lambda> at 0x7fe074f8c280>
     ├┬ F2: <function _create_function at 0x7fe074c49c10>
     │└ # F2 [34 B]
@@ -203,12 +203,12 @@ tools like pickle tracing::
     ││└ # D2 [2 B]
     │└ # D2 [23 B]
     └ # F1 [180 B]
-    >>> dill.detect.trace(False)
 
 With trace, we see how ``dill`` stored the lambda (``F1``) by first storing
 ``_create_function``, the underlying code object (``Co``) and ``_create_code``
 (which is used to handle code objects), then we handle the reference to
-the global dict (``D2``).  A ``#`` marks when the object is actually stored.
+the global dict (``D2``) plus other dictionaries (``D1`` and ``D2``) that
+save the lambda object's state. A ``#`` marks when the object is actually stored.
 
 
 More Information

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -23,8 +23,9 @@ __all__ = ['dump','dumps','load','loads','dump_session','load_session',
 
 __module__ = 'dill'
 
-from .logger import adapter as logger
 import warnings
+from .logger import adapter as logger
+from .logger import trace as _trace
 
 import os
 import sys

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -21,7 +21,7 @@ __all__ = ['dump','dumps','load','loads','dump_session','load_session',
            'UnpicklingError','HANDLE_FMODE','CONTENTS_FMODE','FILE_FMODE',
            'PickleError','PickleWarning','PicklingWarning','UnpicklingWarning']
 
-from .logger import adapter as logger
+from .logger import adapter as logger, trace as _trace
 import warnings
 
 import os

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1472,18 +1472,22 @@ def save_code(pickler, obj):
     logger.trace(pickler, "# Co")
     return
 
+def _repr_dict(obj):
+    """make a short string representation of a dictionary"""
+    return "<%s object at %#012x>" % (type(obj).__name__, id(obj))
+
 @register(dict)
 def save_module_dict(pickler, obj):
     if is_dill(pickler, child=False) and obj == pickler._main.__dict__ and \
             not (pickler._session and pickler._first_pass):
-        logger.trace(pickler, "D1: <dict%s", str(obj.__repr__).split('dict')[-1]) # obj
+        logger.trace(pickler, "D1: %s", _repr_dict(obj)) # obj
         if PY3:
             pickler.write(bytes('c__builtin__\n__main__\n', 'UTF-8'))
         else:
             pickler.write('c__builtin__\n__main__\n')
         logger.trace(pickler, "# D1")
     elif (not is_dill(pickler, child=False)) and (obj == _main_module.__dict__):
-        logger.trace(pickler, "D3: <dict%s", str(obj.__repr__).split('dict')[-1]) # obj
+        logger.trace(pickler, "D3: %s", _repr_dict(obj)) # obj
         if PY3:
             pickler.write(bytes('c__main__\n__dict__\n', 'UTF-8'))
         else:
@@ -1492,14 +1496,14 @@ def save_module_dict(pickler, obj):
     elif '__name__' in obj and obj != _main_module.__dict__ \
     and type(obj['__name__']) is str \
     and obj is getattr(_import_module(obj['__name__'],True), '__dict__', None):
-        logger.trace(pickler, "D4: <dict%s", str(obj.__repr__).split('dict')[-1]) # obj
+        logger.trace(pickler, "D4: %s", _repr_dict(obj)) # obj
         if PY3:
             pickler.write(bytes('c%s\n__dict__\n' % obj['__name__'], 'UTF-8'))
         else:
             pickler.write('c%s\n__dict__\n' % obj['__name__'])
         logger.trace(pickler, "# D4")
     else:
-        logger.trace(pickler, "D2: <dict%s", str(obj.__repr__).split('dict')[-1]) # obj
+        logger.trace(pickler, "D2: %s", _repr_dict(obj)) # obj
         if is_dill(pickler, child=False) and pickler._session:
             # we only care about session the first pass thru
             pickler._first_pass = False
@@ -1871,7 +1875,7 @@ def save_cell(pickler, obj):
 if MAPPING_PROXY_TRICK:
     @register(DictProxyType)
     def save_dictproxy(pickler, obj):
-        logger.trace(pickler, "Mp: %s", obj)
+        logger.trace(pickler, "Mp: %s", _repr_dict(obj)) # obj
         mapping = obj | _dictproxy_helper_instance
         pickler.save_reduce(DictProxyType, (mapping,), obj=obj)
         logger.trace(pickler, "# Mp")
@@ -1879,7 +1883,7 @@ if MAPPING_PROXY_TRICK:
 else:
     @register(DictProxyType)
     def save_dictproxy(pickler, obj):
-        logger.trace(pickler, "Mp: %s" % obj)
+        logger.trace(pickler, "Mp: %s", _repr_dict(obj)) # obj
         pickler.save_reduce(DictProxyType, (obj.copy(),), obj=obj)
         logger.trace(pickler, "# Mp")
         return

--- a/dill/detect.py
+++ b/dill/detect.py
@@ -13,8 +13,8 @@ import dis
 from inspect import ismethod, isfunction, istraceback, isframe, iscode
 from .pointers import parent, reference, at, parents, children
 
-from ._dill import _trace as trace
 from ._dill import PY3
+from .logger import trace
 
 __all__ = ['baditems','badobjects','badtypes','code','errors','freevars',
            'getmodule','globalvars','nestedcode','nestedglobals','outermost',

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -145,8 +145,13 @@ class TraceAdapter(logging.LoggerAdapter):
         try:
             # Streams are not required to be tellable.
             size = pickler._file.tell()
-            size += pickler.framer.current_frame.tell()
-        except AttributeError:
+            frame = pickler.framer.current_frame
+            try:
+                size += frame.tell()
+            except AttributeError:
+                # PyPy may use a BytesBuilder as frame
+                size += len(frame)
+        except (AttributeError, TypeError):
             pass
         if size is not None:
             if not pushed_obj:

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -96,7 +96,7 @@ class TraceAdapter(logging.LoggerAdapter):
                     pickler._size_stack.append(size)
                 else:
                     size -= pickler._size_stack.pop()
-                extra['size'] = size
+                    extra['size'] = size
             if pushed: pickler._trace_depth -= 1
             extra['depth'] = pickler._trace_depth
             kwargs['extra'] = extra

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+#
+# Author: Leonardo Gama (@leogama)
+# Copyright (c) 2022 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/dill/blob/master/LICENSE
+r"""
+Logging utilities for dill.
+
+Python's logging functionality can be conceptually divided into five steps:
+  0. Check logging level -> abort if call level is greater than logger level
+  1. Gather information -> construct a LogRecord from passed arguments and context
+  2. Filter (optional) -> discard message if the record matches a filter
+  3. Format -> format message with args, then format output string with message plus record
+  4. Handle -> write the formatted string to output as defined in the handler
+
+
+Basic calling sequence
+======================
+
+dill.logging.logger.log ->    # or logger.info, etc.
+  Logger.log ->               \
+    Logger._log ->             }- accept 'extra' parameter for custom record entries
+      Logger.makeRecord ->    /
+        LogRecord.__init__
+      Logger.handle ->
+        Logger.callHandlers ->
+          Handler.handle ->
+            Filterer.filter ->
+              Filter.filter
+            StreamHandler.emit ->
+              Handler.format ->
+                Formatter.format ->
+                  LogRecord.getMessage      # does: record.message = msg % args
+                  Formatter.formatMessage ->
+                    PercentStyle.format     # does: self._fmt % record.__dict__
+
+NOTE: All methods from the second line on are from logging.__init__.py
+
+
+Logger customizations
+=====================
+
+Step 1 - Information
+--------------------
+We use a LoggerAdapter subclass to wrap the module's logger, as the logging API
+doesn't allow setting it directly with a custom Logger subclass.  The added
+'log_trace()' method receives a pickle instance as the first argument and
+creates extra values to be added in the LogRecord from it, then calls 'log()'.
+
+Step 3 - Formatting
+-------------------
+We use a Formatter subclass to add prefix and suffix strings to the log message
+in trace mode (an also provide empty defaults for normal logs).  The user may
+substitute the formatter to customize the extra information display.
+"""
+
+__all__ = ['INFO_DETAIL', 'adapter', 'logger', 'trace']
+
+import logging, math
+
+INFO_DETAIL = (logging.INFO + logging.DEBUG) // 2
+
+
+class TraceAdapter(logging.LoggerAdapter):
+    """tracks object graph depth and calculates pickled object size"""
+    def __init__(self, logger):
+        self.logger = logger
+    def process(self, msg, kwargs):
+        # A no-op override, as we don't have self.extra
+        return msg, kwargs
+    def log_trace(self, pickler, msg=None, *args, **kwargs):
+        """log_trace(self, pickler, msg=None, *args, reset=False, **kwargs)"""
+        reset = kwargs.pop('reset', False)
+        if msg is None:
+            # Initialization and clean-up.
+            if reset:
+                pickler._trace_depth = 0
+                pickler._size_stack = None
+            elif self.isEnabledFor(INFO_DETAIL):
+                pickler._trace_depth = 1
+                pickler._size_stack = []
+            return
+
+        elif getattr(pickler, '_trace_depth', None):
+            extra = kwargs.get('extra', {})
+            pushed = msg.startswith('#')
+            size = None
+            try:
+                size = pickler._file.tell()
+                size += pickler.framer.current_frame.tell()
+            except AttributeError:
+                pass
+            if size:
+                if not pushed:
+                    pickler._size_stack.append(size)
+                else:
+                    size -= pickler._size_stack.pop()
+                extra['size'] = size
+            if pushed: pickler._trace_depth -= 1
+            extra['depth'] = pickler._trace_depth
+            kwargs['extra'] = extra
+            self.log(INFO_DETAIL, msg, *args, **kwargs)
+            if not pushed: pickler._trace_depth += 1
+
+        else:
+            self.info(msg, *args, **kwargs)
+
+
+class TraceFormatter(logging.Formatter):
+    """generates message prefix and suffix from record"""
+    def format(self, record):
+        fields = {'prefix': "", 'suffix': ""}
+        if hasattr(record, 'depth'):
+            fields['prefix'] = record.depth*">" + " "
+        if hasattr(record, 'size'):
+            # Show object size in human-redable form.
+            power = int(math.log(record.size, 2)) // 10
+            size = record.size >> power*10
+            fields['suffix'] = " (%d %sB)" % (size, "KMGTP"[power] + "i" if power else "")
+        record.__dict__.update(fields)
+        return super(TraceFormatter, self).format(record)
+
+
+logger = logging.getLogger('dill')
+adapter = TraceAdapter(logger)
+
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+
+formatter = TraceFormatter("%(prefix)s%(message)s%(suffix)s")
+handler.setFormatter(formatter)
+
+
+def trace(boolean, detail=False):
+    """print a trace through the stack when pickling; useful for debugging"""
+    if boolean:
+        logger.setLevel(INFO_DETAIL if detail else logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -42,6 +42,7 @@ its child objects).  Sample trace output:
 
 __all__ = ['adapter', 'logger', 'trace']
 
+import codecs
 import locale
 import logging
 import math
@@ -171,7 +172,12 @@ class TraceFormatter(logging.Formatter):
                 raise AttributeError
         except AttributeError:
             encoding = locale.getpreferredencoding()
-        self.is_utf8 = (encoding == 'UTF-8')
+        try:
+            encoding = codecs.lookup(encoding).name
+        except LookupError:
+            self.is_utf8 = False
+        else:
+            self.is_utf8 = (encoding == codecs.lookup('utf-8').name)
     def format(self, record):
         fields = {'prefix': "", 'suffix': ""}
         if getattr(record, 'depth', 0) > 0:

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -5,149 +5,194 @@
 # Copyright (c) 2022 The Uncertainty Quantification Foundation.
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/dill/blob/master/LICENSE
-r"""
+"""
 Logging utilities for dill.
 
-Python's logging functionality can be conceptually divided into five steps:
-  0. Check logging level -> abort if call level is greater than logger level
-  1. Gather information -> construct a LogRecord from passed arguments and context
-  2. Filter (optional) -> discard message if the record matches a filter
-  3. Format -> format message with args, then format output string with message plus record
-  4. Handle -> write the formatted string to output as defined in the handler
+The 'logger' object is the dill's top-level logger.
 
+The 'adapter' object wraps the logger and implements a 'trace()' method that
+generates a detailed tree-style trace for the pickling call at log level INFO.
 
-Basic calling sequence
-======================
+The 'trace()' function sets and resets dill's logger log level, enabling and
+disabling the pickling trace.
 
-dill.logging.logger.log ->    # or logger.info, etc.
-  Logger.log ->               \
-    Logger._log ->             }- accept 'extra' parameter for custom record entries
-      Logger.makeRecord ->    /
-        LogRecord.__init__
-      Logger.handle ->
-        Logger.callHandlers ->
-          Handler.handle ->
-            Filterer.filter ->
-              Filter.filter
-            StreamHandler.emit ->
-              Handler.format ->
-                Formatter.format ->
-                  LogRecord.getMessage      # does: record.message = msg % args
-                  Formatter.formatMessage ->
-                    PercentStyle.format     # does: self._fmt % record.__dict__
+The trace shows a tree structure depicting the depth of each object serialized
+*with dill save functions*, but not the ones that use save functions from
+'pickle._Pickler.dispatch'. If the information is available, it also displays
+the size in bytes that the object contributed to the pickle stream (including
+its child objects).  Example trace output:
 
-NOTE: All methods from the second line on are from logging.__init__.py
-
-
-Logger customizations
-=====================
-
-Step 1 - Information
---------------------
-We use a LoggerAdapter subclass to wrap the module's logger, as the logging API
-doesn't allow setting it directly with a custom Logger subclass.  The added
-'log_trace()' method receives a pickle instance as the first argument and
-creates extra values to be added in the LogRecord from it, then calls 'log()'.
-
-Step 3 - Formatting
--------------------
-We use a Formatter subclass to add prefix and suffix strings to the log message
-in trace mode (an also provide empty defaults for normal logs).  The user may
-substitute the formatter to customize the extra information display.
+    >>> import dill, dill.tests
+    >>> dill.dump_session(main=dill.tests)
+    ┬ M1: <module 'dill.tests' from '.../dill/tests/__init__.py'>
+    ├┬ F2: <function _import_module at 0x7f0d2dce1b80>
+    │└ # F2 [32 B]
+    ├┬ D2: <dict object at 0x7f0d2e98a540>
+    │├┬ T4: <class '_frozen_importlib.ModuleSpec'>
+    ││└ # T4 [35 B]
+    │├┬ D2: <dict object at 0x7f0d2ef0e8c0>
+    ││├┬ T4: <class '_frozen_importlib_external.SourceFileLoader'>
+    │││└ # T4 [50 B]
+    ││├┬ D2: <dict object at 0x7f0d2e988a40>
+    │││└ # D2 [84 B]
+    ││└ # D2 [413 B]
+    │└ # D2 [763 B]
+    └ # M1 [813 B]
 """
 
-__all__ = ['INFO_DETAIL', 'adapter', 'logger', 'trace']
+__all__ = ['adapter', 'logger', 'trace']
 
-import locale, logging, math
+import dill, locale, logging, math
 
-INFO_DETAIL = (logging.INFO + logging.DEBUG) // 2
+# Tree drawing characters: Unicode to ASCII map.
+ASCII_MAP = str.maketrans({"│": "|", "├": "|", "┬": "+", "└": "`"})
 
-TRANS_TABLE = {ord(k): ord(v) for k, v in zip(u"│├┬└", "||+`")}
+## Notes about the design choices ##
 
+# Here is some domumentation of the Standard Library's logging internals that
+# can't be found completely in the official documentation.  dill's logger is
+# obtained by calling logging.getLogger('dill') and therefore is an instance of
+# logging.getLoggerClass() at the call time.  As this is controlled by the user,
+# in order to add some functionality to it it's necessary to use a LoggerAdapter
+# to wrap it, overriding some of the adapter's methods and creating new ones.
+#
+# Basic calling sequence
+# ======================
+#
+# Python's logging functionality can be conceptually divided into five steps:
+#   0. Check logging level -> abort if call level is greater than logger level
+#   1. Gather information -> construct a LogRecord from passed arguments and context
+#   2. Filter (optional) -> discard message if the record matches a filter
+#   3. Format -> format message with args, then format output string with message plus record
+#   4. Handle -> write the formatted string to output as defined in the handler
+#
+# dill.logging.logger.log ->        # or logger.info, etc.
+#   Logger.log ->               \
+#     Logger._log ->             }- accept 'extra' parameter for custom record entries
+#       Logger.makeRecord ->    /
+#         LogRecord.__init__
+#       Logger.handle ->
+#         Logger.callHandlers ->
+#           Handler.handle ->
+#             Filterer.filter ->
+#               Filter.filter
+#             StreamHandler.emit ->
+#               Handler.format ->
+#                 Formatter.format ->
+#                   LogRecord.getMessage        # does: record.message = msg % args
+#                   Formatter.formatMessage ->
+#                     PercentStyle.format       # does: self._fmt % vars(record)
+#
+# NOTE: All methods from the second line on are from logging.__init__.py
 
 class TraceAdapter(logging.LoggerAdapter):
-    """tracks object graph depth and calculates pickled object size"""
+    """
+    Tracks object tree depth and calculates pickled object size.
+
+    A single instance of this wraps the module's logger, as the logging API
+    doesn't allow setting it directly with a custom Logger subclass.  The added
+    'trace()' method receives a pickle instance as the first argument and
+    creates extra values to be added in the LogRecord from it, then calls
+    'info()'.
+
+    Usage of logger with 'trace()' method:
+
+    >>> from .logger import adapter as logger  # instead of 'from .logger import logger'
+    >>> ...
+    >>> def save_atype(pickler, obj):
+    >>>     logger.trace(pickler, "Message with %s and %r etc. placeholders", 'text', obj)
+    >>>     ...
+    """
     def __init__(self, logger):
         self.logger = logger
+    def addHandler(self, handler):
+        formatter = TraceFormatter("%(prefix)s%(message)s%(suffix)s", handler=handler)
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
+    def removeHandler(self, handler):
+        self.logger.removeHandler(handler)
     def process(self, msg, kwargs):
-        # A no-op override, as we don't have self.extra
+        # A no-op override, as we don't have self.extra.
         return msg, kwargs
-    def log_trace(self, pickler, msg=None, *args, **kwargs):
-        """log_trace(self, pickler, msg=None, *args, reset=False, **kwargs)"""
-        reset = kwargs.pop('reset', False)
-        if msg is None:
-            # Initialization and clean-up.
-            if reset:
-                pickler._trace_depth = 0
-                pickler._size_stack = None
-            elif self.isEnabledFor(INFO_DETAIL):
-                pickler._trace_depth = 1
-                pickler._size_stack = []
+    def trace_setup(self, pickler):
+        # Called by Pickler.dump().
+        if not dill._dill.is_dill(pickler, child=False):
             return
-
-        elif getattr(pickler, '_trace_depth', None):
-            extra = kwargs.get('extra', {})
-            pushed = msg.startswith('#')
-            size = None
-            try:
-                size = pickler._file.tell()
-                size += pickler.framer.current_frame.tell()
-            except AttributeError:
-                pass
-            if size:
-                if not pushed:
-                    pickler._size_stack.append(size)
-                else:
-                    size -= pickler._size_stack.pop()
-                    extra['size'] = size
-            if pushed: pickler._trace_depth -= 1
-            extra['depth'] = pickler._trace_depth
-            kwargs['extra'] = extra
-            self.log(INFO_DETAIL, msg, *args, **kwargs)
-            if not pushed: pickler._trace_depth += 1
-
+        if self.isEnabledFor(logging.INFO):
+            pickler._trace_depth = 1
+            pickler._size_stack = []
         else:
-            self.info(msg, *args, **kwargs)
+            pickler._trace_depth = None
+    def trace(self, pickler, msg, *args, **kwargs):
+        if not hasattr(pickler, '_trace_depth'):
+            logger.info(msg, *args, **kwargs)
+            return
+        if pickler._trace_depth is None:
+            return
+        extra = kwargs.get('extra', {})
+        pushed_obj = msg.startswith('#')
+        size = None
+        try:
+            # Streams are not required to be tellable.
+            size = pickler._file.tell()
+            size += pickler.framer.current_frame.tell()
+        except AttributeError:
+            pass
+        if size is not None:
+            if not pushed_obj:
+                pickler._size_stack.append(size)
+            else:
+                size -= pickler._size_stack.pop()
+                extra['size'] = size
+        if pushed_obj:
+            pickler._trace_depth -= 1
+        extra['depth'] = pickler._trace_depth
+        kwargs['extra'] = extra
+        self.info(msg, *args, **kwargs)
+        if not pushed_obj:
+            pickler._trace_depth += 1
 
 class TraceFormatter(logging.Formatter):
-    """generates message prefix and suffix from record"""
-    def __init__(self, *args, **kwargs):
-        super(TraceFormatter, self).__init__(*args, **kwargs)
-        self.is_utf8 = locale.getpreferredencoding() == 'UTF-8'
+    """
+    Generates message prefix and suffix from record.
+
+    This Formatter adds prefix and suffix strings to the log message in trace
+    mode (an also provides empty string defaults for normal logs).
+    """
+    def __init__(self, *args, handler=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            encoding = handler.stream.encoding
+            if encoding is None:
+                raise AttributeError
+        except AttributeError:
+            encoding = locale.getpreferredencoding()
+        self.is_utf8 = (encoding == 'UTF-8')
     def format(self, record):
         fields = {'prefix': "", 'suffix': ""}
         if getattr(record, 'depth', 0) > 0:
             if record.msg.startswith("#"):
-                prefix = (record.depth-1)*u"│" + u"└ "
+                prefix = (record.depth - 1)*"│" + "└"
             elif record.depth == 1:
-                prefix = u"┬ "
+                prefix = "┬"
             else:
-                prefix = (record.depth-2)*u"│" + u"├┬ "
+                prefix = (record.depth - 2)*"│" + "├┬"
             if not self.is_utf8:
-                prefix = prefix[:-1].translate(TRANS_TABLE) + "- "
-            fields['prefix'] = prefix
+                prefix = prefix.translate(ASCII_MAP) + "-"
+            fields['prefix'] = prefix + " "
         if hasattr(record, 'size'):
             # Show object size in human-redable form.
             power = int(math.log(record.size, 2)) // 10
             size = record.size >> power*10
             fields['suffix'] = " [%d %sB]" % (size, "KMGTP"[power] + "i" if power else "")
-        record.__dict__.update(fields)
-        return super(TraceFormatter, self).format(record)
-
+        vars(record).update(fields)
+        return super().format(record)
 
 logger = logging.getLogger('dill')
 adapter = TraceAdapter(logger)
-
 handler = logging.StreamHandler()
-logger.addHandler(handler)
+adapter.addHandler(handler)
 
-formatter = TraceFormatter("%(prefix)s%(message)s%(suffix)s")
-handler.setFormatter(formatter)
-
-
-def trace(boolean, detail=False):
+def trace(boolean):
     """print a trace through the stack when pickling; useful for debugging"""
-    if boolean:
-        logger.setLevel(INFO_DETAIL if detail else logging.INFO)
-    else:
-        logger.setLevel(logging.WARNING)
+    logger.setLevel(logging.INFO if boolean else logging.WARNING)

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -112,7 +112,14 @@ class TraceFormatter(logging.Formatter):
     def format(self, record):
         fields = {'prefix': "", 'suffix': ""}
         if hasattr(record, 'depth'):
-            fields['prefix'] = record.depth*">" + " "
+            if record.depth <= 0:
+                fields['prefix'] = "" # ???
+            elif record.msg.startswith("#"):
+                fields['prefix'] = (record.depth-1)*"│" + "└ "
+            elif record.depth == 1:
+                fields['prefix'] = "┬ "
+            else:
+                fields['prefix'] = (record.depth-2)*"│" + "├┬ "
         if hasattr(record, 'size'):
             # Show object size in human-redable form.
             power = int(math.log(record.size, 2)) // 10

--- a/dill/logger.py
+++ b/dill/logger.py
@@ -8,7 +8,7 @@
 """
 Logging utilities for dill.
 
-The 'logger' object is the dill's top-level logger.
+The 'logger' object is dill's top-level logger.
 
 The 'adapter' object wraps the logger and implements a 'trace()' method that
 generates a detailed tree-style trace for the pickling call at log level INFO.
@@ -20,7 +20,7 @@ The trace shows a tree structure depicting the depth of each object serialized
 *with dill save functions*, but not the ones that use save functions from
 'pickle._Pickler.dispatch'. If the information is available, it also displays
 the size in bytes that the object contributed to the pickle stream (including
-its child objects).  Example trace output:
+its child objects).  Sample trace output:
 
     >>> import dill, dill.tests
     >>> dill.dump_session(main=dill.tests)
@@ -42,7 +42,11 @@ its child objects).  Example trace output:
 
 __all__ = ['adapter', 'logger', 'trace']
 
-import dill, locale, logging, math
+import locale
+import logging
+import math
+
+import dill
 
 # Tree drawing characters: Unicode to ASCII map.
 ASCII_MAP = str.maketrans({"│": "|", "├": "|", "┬": "+", "└": "`"})

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from io import StringIO
 
-test_obj = {'a': (1, 2), 'b': object(), 'f': lambda x: x**2, 'big': list(range(10000))}
+test_obj = {'a': (1, 2), 'b': object(), 'f': lambda x: x**2, 'big': list(range(10))}
 
 def test_logging(should_trace):
     buffer = StringIO()
@@ -47,7 +47,11 @@ def test_trace_to_file(stream_trace):
     file.close()
     # Apparently, objects can change location in memory...
     reghex = re.compile(r'0x[0-9A-Za-z]+')
-    assert reghex.sub('', file_trace) == reghex.sub('', stream_trace)
+    file_trace, stream_trace = reghex.sub('0x', file_trace), reghex.sub('0x', stream_trace)
+    # PyPy prints dictionary contents with repr(dict)...
+    regdict = re.compile(r'(dict\.__repr__ of ).*')
+    file_trace, stream_trace = regdict.sub(r'\1{}>', file_trace), regdict.sub(r'\1{}>', stream_trace)
+    assert file_trace == stream_trace
 
 if __name__ == '__main__':
     logger.removeHandler(stderr_handler)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -36,9 +36,8 @@ if __name__ == '__main__':
     dill.detect.trace(True)
     test_logging(r'(# )?\w.*[^)]')
     dill.detect.trace(True, detail=True)
-    test_logging(r'>+ '                       # prefix indicating depth
-                 r'(\w.*[^)]'                 # begin pickling object
-                 r'|# \w.* \(\d+ (\wi)?B\))'  # object written (with size)
+    test_logging(r'(\S*┬ \w.*[^)]'              # begin pickling object
+                 r'|│*└ # \w.* \[\d+ (\wi)?B])' # object written (with size)
                  )
     dill.detect.trace(False)
     test_logging()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -36,6 +36,9 @@ if __name__ == '__main__':
     dill.detect.trace(True)
     test_logging(r'(# )?\w.*[^)]')
     dill.detect.trace(True, detail=True)
-    test_logging(r'>+ (# )?\w.* \(\d+ (\wi)?B\)')
+    test_logging(r'>+ '                       # prefix indicating depth
+                 r'(\w.*[^)]'                 # begin pickling object
+                 r'|# \w.* \(\d+ (\wi)?B\))'  # object written (with size)
+                 )
     dill.detect.trace(False)
     test_logging()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# Author: Leonardo Gama (@leogama)
+# Copyright (c) 2022 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/dill/blob/master/LICENSE
+
+import dill, logging, re
+from dill.logger import formatter, handler, logger
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+def test_logging(regex=None):
+    buffer = StringIO()
+    handler = logging.StreamHandler(buffer)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    try:
+        dill.dumps({'a': (1, 2), 'b': object(), 'big': list(range(10000))})
+        if regex is None:
+            assert buffer.getvalue() == ""
+        else:
+            regex = re.compile(regex + '$')
+            for line in buffer.getvalue().splitlines():
+                assert regex.match(line)
+    finally:
+        logger.removeHandler(handler)
+        buffer.close()
+
+if __name__ == '__main__':
+    logger.removeHandler(handler)
+    test_logging()
+    dill.detect.trace(True)
+    test_logging(r'(# )?\w.*[^)]')
+    dill.detect.trace(True, detail=True)
+    test_logging(r'>+ (# )?\w.* \(\d+ (\wi)?B\)')
+    dill.detect.trace(False)
+    test_logging()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -6,7 +6,7 @@
 #  - https://github.com/uqfoundation/dill/blob/master/LICENSE
 
 import dill, logging, re
-from dill.logger import formatter, handler, logger
+from dill.logger import handler, adapter as logger
 
 try:
     from StringIO import StringIO
@@ -16,16 +16,15 @@ except ImportError:
 def test_logging(regex=None):
     buffer = StringIO()
     handler = logging.StreamHandler(buffer)
-    handler.setFormatter(formatter)
     logger.addHandler(handler)
     try:
         dill.dumps({'a': (1, 2), 'b': object(), 'big': list(range(10000))})
         if regex is None:
             assert buffer.getvalue() == ""
         else:
-            regex = re.compile(regex + '$')
+            regex = re.compile(regex)
             for line in buffer.getvalue().splitlines():
-                assert regex.match(line)
+                assert regex.fullmatch(line)
     finally:
         logger.removeHandler(handler)
         buffer.close()
@@ -34,8 +33,6 @@ if __name__ == '__main__':
     logger.removeHandler(handler)
     test_logging()
     dill.detect.trace(True)
-    test_logging(r'(# )?\w.*[^)]')
-    dill.detect.trace(True, detail=True)
     test_logging(r'(\S*┬ \w.*[^)]'              # begin pickling object
                  r'|│*└ # \w.* \[\d+ (\wi)?B])' # object written (with size)
                  )


### PR DESCRIPTION
This is a detailed mode for the trace feature to help to better visualize the hierarchy of the objects being dumped and also to identify large child objects. If it is OK, I will write the documentation.

Usage:

```python
import dill
dill.detect.trace(True, detail=True)
pickled = dill.dumps(obj)
```