### PR TITLE
remove redundant `wheel` dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,5 @@
 # Further build requirements come from setup.py via the PEP 517 interface
 requires = [
     "setuptools>=42",
-    "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is automatically added
by the setuptools build-backend.  Listing it in `pyproject.toml`
was a historical documentation mistake that was fixed recently (see
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a).