### PR TITLE
Bring back old method pickling function

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -54,6 +54,21 @@ def function_with_unassigned_variable():
     return (lambda: value)
 
 
+def test_issue_510():
+    # A very bizzare use of functions and methods that pickle doesn't get
+    # correctly for odd reasons.
+    class Foo:
+        def __init__(self):
+                def f2(self):
+                        return self
+                self.f2 = f2.__get__(self)
+
+    import dill, pickletools
+    f = Foo()
+    f1 = dill.copy(f)
+    assert f1.f2() is f1
+
+
 def test_functions():
     dumped_func_a = dill.dumps(function_a)
     assert dill.loads(dumped_func_a)(0) == 0
@@ -104,3 +119,4 @@ assert dill.loads(dumped_func_e)(1, 2, 3, e2=4, e3=5) == 15''')
 
 if __name__ == '__main__':
     test_functions()
+    test_issue_510()


### PR DESCRIPTION
This is a very strange use case of functions and methods that Python's pickle package doesn't handle correctly (#510). This case used to work in pre-0.3.5 dill, so let's bring back the old dill implementation.

The comments are irrelevant in Python 3.

Fixes #510 