### PR TITLE
A hook that allows dill to save the versions of Python and dill

### DIFF
--- a/dill/__init__.py
+++ b/dill/__init__.py
@@ -290,6 +290,9 @@ from ._dill import dump, dumps, load, loads, dump_session, load_session, \
     PicklingWarning, UnpicklingWarning
 from . import source, temp, detect
 
+_dill._dill = _dill
+_dill.__version__ = __version__
+
 # get global settings
 from .settings import settings
 

--- a/tests/test_version_tags.py
+++ b/tests/test_version_tags.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Author: Anirudh Vegesana (avegesan@cs.stanford.edu)
+# Copyright (c) 2022 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/dill/blob/master/LICENSE
+"""
+test Python version tagging
+"""
+
+import dill, io, sys
+
+def test_version_tag():
+    obj = 8
+    unpickler = dill.Unpickler(io.BytesIO(dill.dumps(obj)))
+    obj_copy = unpickler.load()
+    assert unpickler._version.python.version.hexversion == sys.hexversion
+
+
+if __name__ == '__main__':
+    test_version_tag()


### PR DESCRIPTION
This may be useful later in preventing issues like #488 from occurring in the future. By saving the version of Python and dill in the pickle, we can save some trouble later. I am also OK with removing the dill version, since, with careful planning, we can make sure that we never need to use it. This will add at least 50 bytes to very pickle, so maybe an option to turn it off would be desirable.

@mmckerns thoughts?