### PR TITLE
Fix tox tests so they will actually fail

### DIFF
--- a/dill/tests/__main__.py
+++ b/dill/tests/__main__.py
@@ -23,8 +23,13 @@ tests = glob.glob(suite + os.path.sep + 'test_*.py')
 
 if __name__ == '__main__':
 
+    failed = 0
     for test in tests:
         p = sp.Popen([python, test], shell=shell).wait()
-        if not p:
+        if p:
+            print('F', end='', flush=True)
+            failed = 1
+        else:
             print('.', end='', flush=True)
-    print()
+    print('')
+    exit(failed)

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,4 @@ whitelist_externals =
     bash
 commands =
     {envpython} -m pip install .
-    bash -c "failed=0; for test in dill/tests/__main__.py; do echo $test; \
-             {envpython} $test || failed=1; done; exit $failed"
+    {envpython} dill/tests/__main__.py


### PR DESCRIPTION
As things stand, the tests never fail when run via tox.
`__main__.py` runs each individual test script, but always exits
0, even if a test script exits >0.

Signed-off-by: Adam Williamson <awilliam@redhat.com>