### PR TITLE
Alternative fix for bug when pickling function from unloaded module (fixes #532)

### DIFF
--- a/dill/tests/test_functions.py
+++ b/dill/tests/test_functions.py
@@ -132,7 +132,20 @@ def test_code_object():
         except Exception as error:
             raise Exception("failed to construct code object with format version {}".format(version)) from error
 
+def test_unloaded_module():
+    # Function should be saved as global until module is *re*loaded.
+    from statistics import mean
+    pickle_loaded = dill.dumps(mean)
+    del sys.modules['statistics']
+    pickle_unloaded = dill.dumps(mean)
+    assert 'statistics' not in sys.modules
+    import statistics
+    pickle_reloaded = dill.dumps(mean)
+    assert pickle_unloaded == pickle_loaded
+    assert pickle_reloaded != pickle_loaded
+
 if __name__ == '__main__':
     test_functions()
     test_issue_510()
     test_code_object()
+    test_unloaded_module()


### PR DESCRIPTION
This patch modifies `_locate_function()` and `save_function()` to allow dill to save a **function** from a module that was unloaded, i.e. deleted from the `sys.modules` dictionary, by reference (if it would be saved as global had the module not been unloaded). Note: this is independent of the shared namespace problem.

It may be possible to do the same for classes and methods, but these cases are more complex.