### PR TITLE
Fix `pickles()` flagging `__builtins__` as unpickleable due to the `all()` function

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1983,7 +1983,7 @@ def pickles(obj,exact=False,safe=False,**kwds):
         try:
             #FIXME: should be "(pik == obj).all()" for numpy comparison, though that'll fail if shapes differ
             result = bool(pik.all() == obj.all())
-        except AttributeError:
+        except (AttributeError, TypeError):
             warnings.filterwarnings('ignore')
             result = pik == obj
             warnings.resetwarnings()


### PR DESCRIPTION
Currently:
```python
>>> import dill
>>> dill.pickles(__builtins__)  # __builtins__.all() raises a TypeError for a missing argument
False
>>> dill.copy(__builtins__)
<module 'builtins' (built-in)>
>>> _ is __builtins__
True
```

Expected:
```python
>>> import dill
>>> dill.pickles(__builtins__, exact=True)
True
```