### PR TITLE
Disable logging propagation, use current stderr as output

### DIFF
--- a/dill/logger.py
+++ b/dill/logger.py
@@ -209,8 +209,9 @@ class TraceFormatter(logging.Formatter):
         return super().format(record)
 
 logger = logging.getLogger('dill')
+logger.propagate = False
 adapter = TraceAdapter(logger)
-stderr_handler = logging.StreamHandler()
+stderr_handler = logging._StderrHandler()
 adapter.addHandler(stderr_handler)
 
 def trace(arg: Union[bool, TextIO, str, os.PathLike] = None, *, mode: str = 'a') -> NoReturn:


### PR DESCRIPTION
1. Propagation can create duplicate messages if the root logger has stdout/stderr handlers set (as observed in #540).
2. `StreamHandler()` uses the `sys.stderr` value as of the time of handler creation, `_StderrHandler()` always use the current value of `sys.stderr`.