### PR TITLE
Optimize the numpy hook

### DIFF
--- a/dill/logger.py
+++ b/dill/logger.py
@@ -50,7 +50,7 @@ import logging
 import math
 import os
 from functools import partial
-from typing import NoReturn, TextIO, Union
+from typing import TextIO, Union
 
 import dill
 
@@ -214,7 +214,7 @@ adapter = TraceAdapter(logger)
 stderr_handler = logging._StderrHandler()
 adapter.addHandler(stderr_handler)
 
-def trace(arg: Union[bool, TextIO, str, os.PathLike] = None, *, mode: str = 'a') -> NoReturn:
+def trace(arg: Union[bool, TextIO, str, os.PathLike] = None, *, mode: str = 'a') -> None:
     """print a trace through the stack when pickling; useful for debugging
 
     With a single boolean argument, enable or disable the tracing.

--- a/dill/tests/test_classdef.py
+++ b/dill/tests/test_classdef.py
@@ -128,8 +128,8 @@ def test_dtype():
         import numpy as np
 
         dti = np.dtype('int')
-        assert np.dtype == dill.loads(dill.dumps(np.dtype))
-        assert dti == dill.loads(dill.dumps(dti))
+        assert np.dtype == dill.copy(np.dtype)
+        assert dti == dill.copy(dti)
     except ImportError: pass
 
 
@@ -139,8 +139,7 @@ def test_array_nested():
 
         x = np.array([1])
         y = (x,)
-        dill.dumps(x)
-        assert y == dill.loads(dill.dumps(y))
+        assert y == dill.copy(y)
 
     except ImportError: pass
 

--- a/dill/tests/test_weakref.py
+++ b/dill/tests/test_weakref.py
@@ -14,15 +14,7 @@ class _class:
     def _method(self):
         pass
 
-class _class2:
-    def __call__(self):
-        pass
-
-class _newclass(object):
-    def _method(self):
-        pass
-
-class _newclass2(object):
+class _callable_class:
     def __call__(self):
         pass
 
@@ -32,42 +24,33 @@ def _function():
 
 def test_weakref():
     o = _class()
-    oc = _class2()
-    n = _newclass()
-    nc = _newclass2()
+    oc = _callable_class()
     f = _function
-    z = _class
-    x = _newclass
+    x = _class
 
+    # ReferenceType
     r = weakref.ref(o)
-    dr = weakref.ref(_class())
-    p = weakref.proxy(o)
-    dp = weakref.proxy(_class())
-    c = weakref.proxy(oc)
-    dc = weakref.proxy(_class2())
-
-    m = weakref.ref(n)
-    dm = weakref.ref(_newclass())
-    t = weakref.proxy(n)
-    dt = weakref.proxy(_newclass())
-    d = weakref.proxy(nc)
-    dd = weakref.proxy(_newclass2())
-
+    d_r = weakref.ref(_class())
     fr = weakref.ref(f)
-    fp = weakref.proxy(f)
-    #zr = weakref.ref(z) #XXX: weakrefs not allowed for classobj objects
-    #zp = weakref.proxy(z) #XXX: weakrefs not allowed for classobj objects
     xr = weakref.ref(x)
+
+    # ProxyType
+    p = weakref.proxy(o)
+    d_p = weakref.proxy(_class())
+
+    # CallableProxyType
+    cp = weakref.proxy(oc)
+    d_cp = weakref.proxy(_callable_class())
+    fp = weakref.proxy(f)
     xp = weakref.proxy(x)
 
-    objlist = [r,dr,m,dm,fr,xr, p,dp,t,dt, c,dc,d,dd, fp,xp]
+    objlist = [r,d_r,fr,xr, p,d_p, cp,d_cp,fp,xp]
     #dill.detect.trace(True)
 
     for obj in objlist:
       res = dill.detect.errors(obj)
       if res:
-        print ("%s" % res)
-       #print ("%s:\n  %s" % (obj, res))
+        print ("%r:\n  %s" % (obj, res))
     # else:
     #   print ("PASS: %s" % obj)
       assert not res


### PR DESCRIPTION
As this is now called from `Pickler.save()`, which can be called from a dozen to thousands of times for a single "dump":
- Moved repeated logic to outside the numpy test functions
- Only create a save function once for each type
- Remove logic related to Python 2 old style classes
- Substituted black magic like comparing `id(obj1.__bound_method__) == id(obj2.__bound_method__)`* by  `type(obj1).__unbound_method__ is type(obj2).__unbound_method__)`

(*) I was surprised that it worked at all, must be some kind of optimization but this is not described in the language.

Amend to #540 