### PR TITLE
Drop _abc._abc_data from saving. 

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -29,6 +29,7 @@ import warnings
 from .logger import adapter as logger
 from .logger import trace as _trace
 
+import abc
 import os
 import sys
 diff = None
@@ -1688,6 +1689,8 @@ def save_type(pickler, obj, postproc_list=None):
             if type(slots) == str: slots = (slots,) # __slots__ accepts a single string
             for name in slots:
                 del _dict[name]
+            if isinstance(obj, abc.ABCMeta) and '_abc_impl' in _dict:
+                del _dict['_abc_impl']
             _dict.pop('__dict__', None)
             _dict.pop('__weakref__', None)
             _dict.pop('__prepare__', None)

--- a/dill/tests/test_abc.py
+++ b/dill/tests/test_abc.py
@@ -1,0 +1,24 @@
+import abc
+import dill
+
+def test_deserialize_abc():
+  class MyMeta(metaclass=abc.ABCMeta):
+    _not_abc_impl = 1
+  MyMeta.__module__ = '__main__'
+
+  class MyImpl:
+    pass
+
+  MyMeta.register(MyImpl)
+  assert isinstance(MyImpl(),  MyMeta)
+  # Tests that dill doesn't crash pickling _abc._abc_data.
+  cls = dill.loads(dill.dumps(MyMeta))
+  # Dill doesn't serialise the ABC registry, although it's not clear if
+  # that's on purpose or not.
+  assert not isinstance(MyImpl(), cls)
+  cls.register(MyImpl)
+  assert isinstance(MyImpl(), cls)
+
+
+if __name__ == '__main__':
+    test_deserialize_abc()


### PR DESCRIPTION
This prevents an exception when havng a class implementing an ABCMeta class.

Please review this carefully to make sure it fits with dills workflow.

Background:
When pickling a class that inherits from metaclass=abc.ABCMeta dill crashes with an error:
```
TypeError: cannot pickle '_abc._abc_data' object
```

This can be bypassed by dropping _abc_impl from the dictionary in save_type.