### PR TITLE
Fixed crashed in _dill._is_builtin_module when a module's __file__ is None

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1612,6 +1612,7 @@ def save_weakproxy(pickler, obj):
 
 def _is_builtin_module(module):
     if not hasattr(module, "__file__"): return True
+    if module.__file__ is None: return False
     # If a module file name starts with prefix, it should be a builtin
     # module, so should always be pickled as a reference.
     names = ["base_prefix", "base_exec_prefix", "exec_prefix", "prefix", "real_prefix"]


### PR DESCRIPTION
## Summary

The `_is_builtin_module` function of `dill/_dill.py` has the following check in line 1587

`if not hasattr(module, "__file__"): return True`

If the check is not passed, then `os.path.realpath(module.__file__)` is called later in that function (line 1591).

This causes dill to crash when a module has `__file__` set to `None`. This PR fixes that check so that when `module.__file__ is None`, the module is recognized as not builtin.

Notes:
* Even though https://docs.python.org/3/reference/import.html#file__ specifies that when `__file__` is set it is a string, it will actually be none when importing a module without an `__init__.py` file in it.
* This PR only changes the behavior of dill to prevent TypeError crashes. Code that did not crash before is unaffected by this PR.
* No issue created prior to this PR)