### PR TITLE
test for qualname in get_typedef_type

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1693,7 +1693,7 @@ def _get_typedict_type(cls, clsdict, attrs, postproc_list):
     for name, value in dict.items(clsdict):
         try:
             base_value = inherited_dict[name]
-            if value is base_value:
+            if value is base_value and hasattr(value, '__qualname__'):
                 to_remove.append(name)
         except KeyError:
             pass

--- a/dill/tests/test_abc.py
+++ b/dill/tests/test_abc.py
@@ -77,7 +77,8 @@ def test_abc_non_local():
     # Set a property that StockPickle can't preserve
     instance.bar = lambda x: x**2
     depickled = dill.copy(instance)
-    assert type(depickled) is not type(instance)
+    assert type(depickled) is type(instance) #NOTE: issue #612, test_abc_local
+    #NOTE: dill.copy of local (or non-local) classes should (not) be the same?
     assert type(depickled.bar) is FunctionType
     assert depickled.bar(3) == 9
     assert depickled.sfoo() == "Static Method SFOO"
@@ -99,7 +100,7 @@ def test_abc_local():
     labc = dill.copy(LocalABC)
     assert labc is not LocalABC
     assert type(labc) is type(LocalABC)
-    # TODO should work like it does for non local classes
+    #NOTE: dill.copy of local (or non-local) classes should (not) be the same?
     # <class '__main__.LocalABC'>
     # <class '__main__.test_abc_local.<locals>.LocalABC'>
 

--- a/dill/tests/test_classdef.py
+++ b/dill/tests/test_classdef.py
@@ -276,6 +276,31 @@ def test_enummeta():
     assert dill.copy(HTTPStatus.OK) is HTTPStatus.OK
     assert dill.copy(enum.EnumMeta) is enum.EnumMeta
 
+def test_inherit(): #NOTE: see issue #612
+    class Foo:
+        w = 0
+        x = 1
+        y = 1.1
+
+    class Bar(Foo):
+        w = 2
+        x = 1
+        y = 1.1
+        z = 0.2
+
+    Baz = dill.copy(Bar)
+
+    assert Bar.__dict__ == Baz.__dict__
+    assert 'w' in Bar.__dict__ and 'w' in Baz.__dict__
+    assert Bar.__dict__['w'] is Baz.__dict__['w']
+    assert 'x' in Bar.__dict__ and 'x' in Baz.__dict__
+    assert Bar.__dict__['x'] is Baz.__dict__['x']
+    assert 'y' in Bar.__dict__ and 'y' in Baz.__dict__
+    assert Bar.__dict__['y'] is not Baz.__dict__['y']
+    assert 'z' in Bar.__dict__ and 'z' in Baz.__dict__
+    assert Bar.__dict__['z'] is not Baz.__dict__['z']
+
+
 if __name__ == '__main__':
     test_class_instances()
     test_class_objects()
@@ -289,3 +314,4 @@ if __name__ == '__main__':
     test_origbases()
     test_metaclass()
     test_enummeta()
+    test_inherit()

--- a/dill/tests/test_classdef.py
+++ b/dill/tests/test_classdef.py
@@ -281,24 +281,47 @@ def test_inherit(): #NOTE: see issue #612
         w = 0
         x = 1
         y = 1.1
+        a = ()
+        b = (1,)
+        n = None
 
     class Bar(Foo):
         w = 2
         x = 1
         y = 1.1
         z = 0.2
+        a = ()
+        b = (1,)
+        c = (2,)
+        n = None
 
     Baz = dill.copy(Bar)
 
+    import platform
+    is_pypy = platform.python_implementation() == 'PyPy'
     assert Bar.__dict__ == Baz.__dict__
+    # ints
     assert 'w' in Bar.__dict__ and 'w' in Baz.__dict__
     assert Bar.__dict__['w'] is Baz.__dict__['w']
     assert 'x' in Bar.__dict__ and 'x' in Baz.__dict__
     assert Bar.__dict__['x'] is Baz.__dict__['x']
+    # floats
     assert 'y' in Bar.__dict__ and 'y' in Baz.__dict__
-    assert Bar.__dict__['y'] is not Baz.__dict__['y']
+    same = Bar.__dict__['y'] is Baz.__dict__['y']
+    assert same if is_pypy else not same
     assert 'z' in Bar.__dict__ and 'z' in Baz.__dict__
-    assert Bar.__dict__['z'] is not Baz.__dict__['z']
+    same = Bar.__dict__['z'] is Baz.__dict__['z']
+    assert same if is_pypy else not same
+    # tuples
+    assert 'a' in Bar.__dict__ and 'a' in Baz.__dict__
+    assert Bar.__dict__['a'] is Baz.__dict__['a']
+    assert 'b' in Bar.__dict__ and 'b' in Baz.__dict__
+    assert Bar.__dict__['b'] is not Baz.__dict__['b']
+    assert 'c' in Bar.__dict__ and 'c' in Baz.__dict__
+    assert Bar.__dict__['c'] is not Baz.__dict__['c']
+    # None
+    assert 'n' in Bar.__dict__ and 'n' in Baz.__dict__
+    assert Bar.__dict__['n'] is Baz.__dict__['n']
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Fixes #612. Test if values in the inherited dict are the same only if they have a qualname. If qualname is not used, then `'__module__'` is incorrectly set to `'dill._dill'` when it is `'__main__'`... and additionally, attributes defined in the super class with values that are flyweights or singletons (i.e. have the same hash) that are also defined in the derived class should always appear in the derived class's `__dict__`.

This PR also changes an assertion in test_abc that synchronizes previously incongruous behavior of ABC classes (there was a TODO note). I believe the new behavior is correct, in that is is more consistent with other classes behavior after pickling an instance of the class.

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added rationale for any breakage of backwards compatibility.
- [ ] Requested a review.
