### PR TITLE
Import submodule properly when there is an attribute of the module with the same name

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1023,9 +1023,12 @@ def _import_module(import_name, safe=False):
             items = import_name.split('.')
             module = '.'.join(items[:-1])
             obj = items[-1]
+            submodule = getattr(__import__(module, None, None, [obj]), obj)
+            if isinstance(submodule, (ModuleType, type)):
+                return submodule
+            return __import__(import_name, None, None, [obj])
         else:
             return __import__(import_name)
-        return getattr(__import__(module, None, None, [obj]), obj)
     except (ImportError, AttributeError, KeyError):
         if safe:
             return None


### PR DESCRIPTION
## Summary
Fixes https://github.com/uqfoundation/dill/issues/628 and fixes https://github.com/uqfoundation/dill/issues/604 : I have checked that they don't throw errors now.

Not sure if it breaks anything else - some of the tests on my machine failed on the master branch - but the tests run the exact same after this change.

Not sure if a test should be added, something like https://github.com/kelvinburke/dill-issue - but I'm not sure the best way?

## Checklist

<!-- Please delete any checkboxes that do not apply to this PR. -->

**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Artifacts produced with the main branch work as expected under this PR. -- Not sure what this means?

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added a comment to issue #NNN, linking back to this PR.
- [ ] Added rationale for any breakage of backwards compatibility. -- Not sure if this does break backwards compatibility?
- [x] Requested a review.

Let me know what you think!