### PR TITLE
formal support for 3.12, initial support for 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,24 @@ matrix:
         - python: '3.11'
           env:
 
-        - python: '3.12-dev'
+        - python: '3.12'
+          env:
+
+        - python: '3.13-dev'
           env:
 
         - python: 'pypy3.8-7.3.9' # at 7.3.11
           env:
 
-        - python: 'pypy3.9-7.3.9' # at 7.3.12
+        - python: 'pypy3.9-7.3.9' # at 7.3.13
           env:
 
-        - python: 'pypy3.10-7.3.12'
+        - python: 'pypy3.10-7.3.13'
           env:
 
     allow_failures:
-        - python: '3.12-dev'
-        - python: 'pypy3.10-7.3.12' # CI missing
+        - python: '3.13-dev'
+        - python: 'pypy3.10-7.3.13' # CI missing
     fast_finish: true
 
 cache:

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -2018,9 +2018,11 @@ if HAS_CTYPES and hasattr(ctypes, 'pythonapi'):
     _PyCapsule_SetName.argtypes = (ctypes.py_object, ctypes.c_char_p)
     _PyCapsule_SetPointer = ctypes.pythonapi.PyCapsule_SetPointer
     _PyCapsule_SetPointer.argtypes = (ctypes.py_object, ctypes.c_void_p)
+    #from _socket import CAPI as _testcapsule
+    _testcapsule_name = b'dill._dill._testcapsule'
     _testcapsule = _PyCapsule_New(
         ctypes.cast(_PyCapsule_New, ctypes.c_void_p),
-        ctypes.create_string_buffer(b'dill._dill._testcapsule'),
+        ctypes.c_char_p(_testcapsule_name),
         None
     )
     PyCapsuleType = type(_testcapsule)

--- a/dill/_objects.py
+++ b/dill/_objects.py
@@ -109,7 +109,10 @@ if HAS_CTYPES:
         pass
     _Struct._fields_ = [("_field", ctypes.c_int),("next", ctypes.POINTER(_Struct))]
 _filedescrip, _tempfile = tempfile.mkstemp('r') # deleted in cleanup
-_tmpf = tempfile.TemporaryFile('w') #FIXME: _tmpf.close() in cleanup?
+if sys.hexversion < 0x30d00a1:
+    _tmpf = tempfile.TemporaryFile('w') # emits OSError 9 in python 3.13
+else:
+    _tmpf = tempfile.NamedTemporaryFile('w').file # for > python 3.9
 
 # objects used by dill for type declaration
 registered = d = {}

--- a/dill/_objects.py
+++ b/dill/_objects.py
@@ -39,7 +39,6 @@ import zlib
 import gzip
 import zipfile
 import tarfile
-import xdrlib
 import csv
 import hashlib
 import hmac
@@ -110,7 +109,7 @@ if HAS_CTYPES:
         pass
     _Struct._fields_ = [("_field", ctypes.c_int),("next", ctypes.POINTER(_Struct))]
 _filedescrip, _tempfile = tempfile.mkstemp('r') # deleted in cleanup
-_tmpf = tempfile.TemporaryFile('w')
+_tmpf = tempfile.TemporaryFile('w') #FIXME: _tmpf.close() in cleanup?
 
 # objects used by dill for type declaration
 registered = d = {}
@@ -313,7 +312,9 @@ if HAS_ALL:
 a['TarFileType'] = tarfile.open(fileobj=_fileW,mode='w')
 # file formats (CH 13)
 x['DialectType'] = csv.get_dialect('excel')
-a['PackerType'] = xdrlib.Packer()
+if sys.hexversion < 0x30d00a1:
+    import xdrlib
+    a['PackerType'] = xdrlib.Packer()
 # optional operating system services (CH 16)
 a['LockType'] = threading.Lock()
 a['RLockType'] = threading.RLock()

--- a/dill/detect.py
+++ b/dill/detect.py
@@ -150,7 +150,7 @@ def nestedglobals(func, recurse=True):
         if '_GLOBAL' in line:
             name = line.split('(')[-1].split(')')[0]
             if CAN_NULL:
-                names.add(name.replace('NULL + ', ''))
+                names.add(name.replace('NULL + ', '').replace(' + NULL', ''))
             else:
                 names.add(name)
     for co in getattr(func, 'co_consts', tuple()):

--- a/dill/tests/test_objects.py
+++ b/dill/tests/test_objects.py
@@ -35,7 +35,7 @@ special['MethodType'] = _method = _class()._method
 special['UnboundMethodType'] = _class._method
 objects.update(special)
 
-def pickles(name, exact=False):
+def pickles(name, exact=False, verbose=True):
     """quick check if object pickles with dill"""
     obj = objects[name]
     try:
@@ -45,19 +45,19 @@ def pickles(name, exact=False):
                 assert pik == obj
             except AssertionError:
                 assert type(obj) == type(pik)
-                print ("weak: %s %s" % (name, type(obj)))
+                if verbose: print ("weak: %s %s" % (name, type(obj)))
         else:
             assert type(obj) == type(pik)
     except Exception:
-        print ("fails: %s %s" % (name, type(obj)))
+        if verbose: print ("fails: %s %s" % (name, type(obj)))
 
 
-def test_objects():
+def test_objects(verbose=True):
     for member in objects.keys():
-       #pickles(member, exact=True)
-        pickles(member, exact=False)
+       #pickles(member, exact=True, verbose=verbose)
+        pickles(member, exact=False, verbose=verbose)
 
 if __name__ == '__main__':
     import warnings
     warnings.simplefilter('ignore')
-    test_objects()
+    test_objects(verbose=False)

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_kwds = dict(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py310
     py311
     py312
+    py313
     pypy38
     pypy39
     pypy310


### PR DESCRIPTION
## Summary
add formal support for python 3.12, initial support for python 3.13

fixes SyntaxWarning for 3.13 in `dill.detect` and for removed module in `dill._objects`.
fixes construction of internal `PyCapsule` object `testcapsule`.

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.