### PR TITLE
add guard for math.log in Logger record size calculation

### DIFF
--- a/dill/logger.py
+++ b/dill/logger.py
@@ -200,8 +200,8 @@ class TraceFormatter(logging.Formatter):
             if not self.is_utf8:
                 prefix = prefix.translate(ASCII_MAP) + "-"
             fields['prefix'] = prefix + " "
-        if hasattr(record, 'size'):
-            # Show object size in human-redable form.
+        if hasattr(record, 'size') and record.size is not None and record.size >= 1:
+            # Show object size in human-readable form.
             power = int(math.log(record.size, 2)) // 10
             size = record.size >> power*10
             fields['suffix'] = " [%d %sB]" % (size, "KMGTP"[power] + "i" if power else "")


### PR DESCRIPTION
## Summary
fixes #635 by guarding the `math.log` from both None and zero, and additionally incorrect calculations for size < 1.

## Checklist

<!-- Please delete any checkboxes that do not apply to this PR. -->

**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added a comment to issue #NNN, linking back to this PR.
- [ ] Added rationale for any breakage of backwards compatibility.
