### PR TITLE
skip BufferedRandomType on pyodide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ matrix:
         - python: 'pypy3.8-7.3.9' # at 7.3.11
           env:
 
-        - python: 'pypy3.9-7.3.9' # at 7.3.13
+        - python: 'pypy3.9-7.3.9' # at 7.3.15
           env:
 
-        - python: 'pypy3.10-7.3.13'
+        - python: 'pypy3.10-7.3.15'
           env:
 
     allow_failures:
         - python: '3.13-dev'
-        - python: 'pypy3.10-7.3.13' # CI missing
+        - python: 'pypy3.10-7.3.15' # CI missing
     fast_finish: true
 
 cache:


### PR DESCRIPTION
## Summary
BufferedRandomType is not defined on Pyodide, so skip this type.
fixes: #643 

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added a comment to issue #NNN, linking back to this PR.