### PR TITLE
further skip BufferedRandomType if does not exist

### DIFF
--- a/dill/_objects.py
+++ b/dill/_objects.py
@@ -72,6 +72,8 @@ except ImportError: # MacPorts
     HAS_CTYPES = False
     IS_PYPY = False
 
+IS_PYODIDE = sys.platform == 'emscripten'
+
 # helper objects
 class _class:
     def _method(self):
@@ -250,13 +252,15 @@ a['NotImplementedType'] = NotImplemented
 a['SliceType'] = slice(1)
 a['UnboundMethodType'] = _class._method #XXX: works when not imported!
 d['TextWrapperType'] = open(os.devnull, 'r') # same as mode='w','w+','r+'
-d['BufferedRandomType'] = open(os.devnull, 'r+b') # same as mode='w+b'
+if not IS_PYODIDE:
+    d['BufferedRandomType'] = open(os.devnull, 'r+b') # same as mode='w+b'
 d['BufferedReaderType'] = open(os.devnull, 'rb') # (default: buffering=-1)
 d['BufferedWriterType'] = open(os.devnull, 'wb')
 try: # oddities: deprecated
     from _pyio import open as _open
     d['PyTextWrapperType'] = _open(os.devnull, 'r', buffering=-1)
-    d['PyBufferedRandomType'] = _open(os.devnull, 'r+b', buffering=-1)
+    if not IS_PYODIDE:
+        d['PyBufferedRandomType'] = _open(os.devnull, 'r+b', buffering=-1)
     d['PyBufferedReaderType'] = _open(os.devnull, 'rb', buffering=-1)
     d['PyBufferedWriterType'] = _open(os.devnull, 'wb', buffering=-1)
 except ImportError:

--- a/dill/tests/test_selected.py
+++ b/dill/tests/test_selected.py
@@ -45,7 +45,8 @@ _newclass = objects['ClassObjectType']
 # some clean-up #FIXME: should happen internal to dill
 objects['TemporaryFileType'].close()
 objects['TextWrapperType'].close()
-objects['BufferedRandomType'].close()
+if 'BufferedRandomType' in objects:
+    objects['BufferedRandomType'].close()
 objects['BufferedReaderType'].close()
 objects['BufferedWriterType'].close()
 objects['FileType'].close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ tag_build = .dev0
 
 [bdist_wheel]
 #python-tag = py3
-#plat-name = manylinux_2_24_x86_64
+#plat-name = manylinux_2_28_x86_64
 
 [sdist]
 #formats=zip,gztar


### PR DESCRIPTION
## Summary
fix: #643 more compatibility with Pyodide, in skipping `BufferedRandomType` in objects and tests.