### PR TITLE
fix fencepost error when getting source inside decorator in interpreter (fixes #603)

### DIFF
--- a/dill/source.py
+++ b/dill/source.py
@@ -150,7 +150,7 @@ def findsource(object):
         if err:
             raise IOError(err)
         lbuf = readline.get_current_history_length()
-        lines = [readline.get_history_item(i)+'\n' for i in range(1,lbuf)]
+        lines = [readline.get_history_item(i)+'\n' for i in range(1,lbuf+1)]
     else:
         try: # special handling for class instances
             if not isclass(object) and isclass(type(object)): # __class__


### PR DESCRIPTION
## Summary
I *believe* this fixes an off-by-one error for functions defined in the interpreter.

I am not sure how to test this as it only runs when directly instantiated in an interpreter.
Fixes https://github.com/uqfoundation/dill/issues/603.


Inline test:

```python
from dill.source import getsource

def my_decorator(foo):
    s = getsource(foo)
    print(s)
    assert s.endswith("return 1\n")

@my_decorator
def foo():
  return 1
```

**Before**

```raw
@my_decorator
def foo():

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in my_decorator
AssertionError
```

**After**
```python
@my_decorator
def foo():
    return 1
>>>
```

Please let me know any suggestions for how to implement a test for this!

<!-- Please delete any checkboxes that do not apply to this PR. -->
## Checklist

**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [ ] Added a comment to issue #NNN, linking back to this PR.
- [ ] Added rationale for any breakage of backwards compatibility.
- [ ] Requested a review.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Create a new branch for your changes and open the PR from your new branch.

- The PR title should summarize the proposed changes, for example
  "Drop support for python 2.7". Avoid non-descriptive titles such as
  "Addresses issue #8576". Do not include the issue number in the title.

- The summary should provide at least 1-2 sentences describing the PR
  in detail. Why is this change required? What problem does it solve?

- If this PR fixes an issue, please read https://tinyurl.com/auto-closing,
  and follow the formatting suggestions to link relevant issues to this PR.

- If you are contributing fixes to docstrings, please pay attention to
  docstring formatting.  In particular, note the difference between using
  single backquotes, double backquotes, and asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
