### PR TITLE
diff USE_NUMPY imports numpy.ma

### DIFF
--- a/dill/__diff.py
+++ b/dill/__diff.py
@@ -15,7 +15,7 @@ import os
 import sys
 import types
 try:
-    import numpy
+    import numpy.ma
     HAS_NUMPY = True
 except ImportError:
     HAS_NUMPY = False


### PR DESCRIPTION
## Summary
numpy >= 2.0.0 doesn't import `numpy.ma` upon import of `numpy`.  As we need `MaskedConstant`, import `numpy.ma`. Fixes #667 

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added a comment to issue #NNN, linking back to this PR.