### PR TITLE
adjust testing to account for frame.f_locals as a proxy in 3.13

### DIFF
--- a/dill/tests/test_detect.py
+++ b/dill/tests/test_detect.py
@@ -29,7 +29,8 @@ def test_bad_things():
     s = set([(err.__class__.__name__,err.args[0]) for err in list(errors(f, 1).values())])
     a = dict(s)
     if not os.environ.get('COVERAGE'): #XXX: travis-ci
-        assert len(s) is len(a) # TypeError (and possibly PicklingError)
+        proxy = 0 if type(f.f_locals) is dict else 1
+        assert len(s) == len(a) + proxy # TypeError (and possibly PicklingError)
     n = 2
     assert len(a) is n if 'PicklingError' in a.keys() else n-1
 


### PR DESCRIPTION
## Summary
In python 3.13, the `f_locals` attribute can be a `FrameLocalsProxy` and not a `dict`, thus the `test_bad_objects` test needs to be modified to account for that.
 
## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.