### PR TITLE
better handle import strings of numpy scalars

### DIFF
--- a/dill/source.py
+++ b/dill/source.py
@@ -602,10 +602,13 @@ def dumpsource(object, alias='', new=False, enclose=True):
 
 def getname(obj, force=False, fqn=False): #XXX: throw(?) to raise error on fail?
     """get the name of the object. for lambdas, get the name of the pointer """
-    if fqn: return '.'.join(_namespace(obj))
+    if fqn: return '.'.join(_namespace(obj)) #NOTE: returns 'type'
     module = getmodule(obj)
     if not module: # things like "None" and "1"
-        if not force: return None
+        if not force: return None #NOTE: returns 'instance' NOT 'type' #FIXME?
+        # handle some special cases
+        if hasattr(obj, 'dtype') and not obj.shape:
+            return getname(obj.__class__) + "(" + repr(obj.tolist()) + ")" 
         return repr(obj)
     try:
         #XXX: 'wrong' for decorators and curried functions ?
@@ -740,6 +743,8 @@ def getimport(obj, alias='', verify=True, builtin=False, enclosing=False):
     except Exception: # it's probably something 'importable'
         if head in ['builtins','__builtin__']:
             name = repr(obj) #XXX: catch [1,2], (1,2), set([1,2])... others?
+        elif _isinstance(obj):
+            name = getname(obj, force=True).split('(')[0]
         else:
             name = repr(obj).split('(')[0]
    #if not repr(obj).startswith('<'): name = repr(obj).split('(')[0]

--- a/dill/tests/test_source.py
+++ b/dill/tests/test_source.py
@@ -130,12 +130,29 @@ def test_importable():
 
 def test_numpy():
   try:
-    from numpy import array
-    x = array([1,2,3])
+    import numpy as np
+    y = np.array
+    x = y([1,2,3])
     assert getimportable(x) == 'from numpy import array\narray([1, 2, 3])\n'
-    assert getimportable(array) == 'from %s import array\n' % array.__module__
+    assert getimportable(y) == 'from %s import array\n' % y.__module__
     assert getimportable(x, byname=False) == 'from numpy import array\narray([1, 2, 3])\n'
-    assert getimportable(array, byname=False) == 'from %s import array\n' % array.__module__
+    assert getimportable(y, byname=False) == 'from %s import array\n' % y.__module__
+    y = np.int64
+    x = y(0)
+    assert getimportable(x) == 'from numpy import int64\nint64(0)\n'
+    assert getimportable(y) == 'from %s import int64\n' % y.__module__
+    assert getimportable(x, byname=False) == 'from numpy import int64\nint64(0)\n'
+    assert getimportable(y, byname=False) == 'from %s import int64\n' % y.__module__
+    y = np.bool_
+    x = y(0)
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=FutureWarning)
+        b = 'bool' if hasattr(np, 'bool') else 'bool_'
+    assert getimportable(x) == 'from numpy import %s\n%s(False)\n' % (b,b)
+    assert getimportable(y) == 'from %s import %s\n' % (y.__module__,b)
+    assert getimportable(x, byname=False) == 'from numpy import %s\n%s(False)\n' % (b,b)
+    assert getimportable(y, byname=False) == 'from %s import %s\n' % (y.__module__,b)
   except ImportError: pass
 
 #NOTE: if before likely_import(pow), will cause pow to throw AssertionError

--- a/dill/tests/test_source.py
+++ b/dill/tests/test_source.py
@@ -148,7 +148,9 @@ def test_numpy():
     import warnings
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=FutureWarning)
-        b = 'bool' if hasattr(np, 'bool') else 'bool_'
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
+        if hasattr(np, 'bool'): b = 'bool_' if np.bool is bool else 'bool'
+        else: b = 'bool_'
     assert getimportable(x) == 'from numpy import %s\n%s(False)\n' % (b,b)
     assert getimportable(y) == 'from %s import %s\n' % (y.__module__,b)
     assert getimportable(x, byname=False) == 'from numpy import %s\n%s(False)\n' % (b,b)


### PR DESCRIPTION
## Summary
fixes #674 and other handling of `numpy` scalars in `dill.source`

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [ ] Added a comment to issue #NNN, linking back to this PR.
- [x] Added rationale for any breakage of backwards compatibility.