### PR TITLE
add initial support for python 3.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ matrix:
         - python: '3.12'
           env:
 
-        - python: '3.13-dev'
+        - python: '3.13'
+          env:
+
+        - python: '3.14-dev'
           env:
 
         - python: 'pypy3.8-7.3.9' # at 7.3.11
@@ -33,6 +36,7 @@ matrix:
           env:
 
     allow_failures:
+        - python: '3.14-dev' # CI missing
         - python: 'pypy3.10-7.3.17' # CI missing
     fast_finish: true
 

--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1125,7 +1125,10 @@ def _save_with_postproc(pickler, reduction, is_pickler_dill=None, obj=Getattr.NO
                 dest, source = reduction[1]
                 if source:
                     pickler.write(pickler.get(pickler.memo[id(dest)][0]))
-                    pickler._batch_setitems(iter(source.items()))
+                    if sys.hexversion < 0x30e00a1:
+                        pickler._batch_setitems(iter(source.items()))
+                    else:
+                        pickler._batch_setitems(iter(source.items()), obj=obj)
                 else:
                     # Updating with an empty dictionary. Same as doing nothing.
                     continue

--- a/dill/_objects.py
+++ b/dill/_objects.py
@@ -164,7 +164,6 @@ a['DateTimeType'] = datetime.datetime.today()
 a['CalendarType'] = calendar.Calendar()
 # numeric and mathematical types (CH 9)
 a['DecimalType'] = decimal.Decimal(1)
-a['CountType'] = itertools.count(0)
 # data compression and archiving (CH 12)
 a['TarInfoType'] = tarfile.TarInfo()
 # generic operating system services (CH 15)
@@ -298,7 +297,6 @@ a['QueueType'] = Queue.Queue()
 # numeric and mathematical types (CH 9)
 d['PartialType'] = functools.partial(int,base=2)
 a['IzipType'] = zip('0','1')
-a['ChainType'] = itertools.chain('0','1')
 d['ItemGetterType'] = operator.itemgetter(0)
 d['AttrGetterType'] = operator.attrgetter('__repr__')
 # file and directory access (CH 10)
@@ -349,8 +347,6 @@ try: # numpy #FIXME: slow... 0.05 to 0.1 sec to import numpy
     a['NumpyInt32Type'] = _numpy_int32
 except ImportError:
     pass
-# numeric and mathematical types (CH 9)
-a['ProductType'] = itertools.product('0','1')
 # generic operating system services (CH 15)
 a['FileHandlerType'] = logging.FileHandler(os.devnull)
 a['RotatingFileHandlerType'] = logging.handlers.RotatingFileHandler(os.devnull)
@@ -413,8 +409,6 @@ if sys.hexversion >= 0x30b00b0:
 
 # data types (CH 8)
 a['PrettyPrinterType'] = pprint.PrettyPrinter()
-# numeric and mathematical types (CH 9)
-a['CycleType'] = itertools.cycle('0')
 # file and directory access (CH 10)
 a['TemporaryFileType'] = _tmpf
 # data compression and archiving (CH 12)
@@ -422,10 +416,16 @@ x['GzipFileType'] = gzip.GzipFile(fileobj=_fileW)
 # generic operating system services (CH 15)
 a['StreamHandlerType'] = logging.StreamHandler()
 # numeric and mathematical types (CH 9)
-a['PermutationsType'] = itertools.permutations('0')
-a['CombinationsType'] = itertools.combinations('0',1)
-a['RepeatType'] = itertools.repeat(0)
-a['CompressType'] = itertools.compress('0',[1])
+z = a if sys.hexversion < 0x30e00a1 else x
+z['CountType'] = itertools.count(0) #FIXME: __reduce__ removed in 3.14.0a1
+z['ChainType'] = itertools.chain('0','1')
+z['ProductType'] = itertools.product('0','1')
+z['CycleType'] = itertools.cycle('0')
+z['PermutationsType'] = itertools.permutations('0')
+z['CombinationsType'] = itertools.combinations('0',1)
+z['RepeatType'] = itertools.repeat(0)
+z['CompressType'] = itertools.compress('0',[1])
+del z
 #XXX: ...and etc
 
 # -- dill fails on all below here -------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
 # Packages required to build docs
 # dependencies pinned as:
-# https://github.com/readthedocs/readthedocs.org/blob/d3606da9907bb4cd933abcf71c7bab9eb20435cd/requirements/docs.txt
+# https://github.com/readthedocs/readthedocs.org/blob/71a82c94adbacf87b4630288f91f1a56e05f54f2/requirements/docs.txt
 
 alabaster==0.7.16
 anyio==4.4.0
 babel==2.15.0
-certifi==2024.7.4
+certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
@@ -47,10 +47,11 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.7
 sphinxcontrib-serializinghtml==1.1.10
+phinxext-opengraph==0.9.1
 starlette==0.37.2
 tomli==2.0.1
 typing-extensions==4.12.1
-urllib3==2.2.2
+urllib3==2.2.1
 uvicorn==0.30.0
 watchfiles==0.22.0
 websockets==12.0

--- a/setup.py
+++ b/setup.py
@@ -123,9 +123,3 @@ except ImportError:
     if sys.platform[:3] == 'win':
         print ("    %s (optional)" % pyreadline_version)
     print ("***********************************************************\n")
-
-
-if __name__=='__main__':
-    pass
-
-# end of file

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     py311
     py312
     py313
+    py314
     pypy38
     pypy39
     pypy310


### PR DESCRIPTION
## Summary
add initial support for python 3.14
Fixes: #690 

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added rationale for any breakage of backwards compatibility.