### PR TITLE
use get_file_type to open _pyio file types

### DIFF
--- a/dill/tests/test_selected.py
+++ b/dill/tests/test_selected.py
@@ -44,11 +44,6 @@ load_types(pickleable=True,unpickleable=False)
 _newclass = objects['ClassObjectType']
 # some clean-up #FIXME: should happen internal to dill
 objects['TemporaryFileType'].close()
-objects['TextWrapperType'].close()
-if 'BufferedRandomType' in objects:
-    objects['BufferedRandomType'].close()
-objects['BufferedReaderType'].close()
-objects['BufferedWriterType'].close()
 objects['FileType'].close()
 del objects
 


### PR DESCRIPTION
## Summary
use `dill._dill.get_file_type` to open file types from `_pyio`, as using `_pyio.open` directly causes error from call of `IOBase.__del__`.  Enables removal of some cleanup in `test_selected.py`

## Checklist

<!-- Please delete any checkboxes that do not apply to this PR. -->

**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [ ] Added a comment to issue #NNN, linking back to this PR.
- [ ] Added rationale for any breakage of backwards compatibility.
- [ ] Requested a review.
