### PR TITLE
update rtfd to 3.12 and docs requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 # install
 python:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -48,7 +48,7 @@ sphinxcontrib-serializinghtml==2.0.0
 sphinxext-opengraph==0.10.0
 starlette==0.47.0
 typing-extensions==4.13.2
-urllib3==2.4.0
+urllib3==2.5.0
 uvicorn==0.34.2
 watchfiles==1.0.5
 websockets==15.0.1


### PR DESCRIPTION
## Summary
update rtfd to 3.12 and docs/requirements to use urllib 2.5.0

