### PR TITLE
dict and weakref descriptors are singletons in 3.15

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -1040,7 +1040,10 @@ def _getattr(objclass, name, repr_str):
         try:
             attr = objclass.__dict__
             if type(attr) is DictProxyType:
-                attr = attr[name]
+                if sys.hexversion > 0x30f00a0 and name in ('__weakref__','__dict__'):
+                    attr = _dictproxy_helper.__dict__[name]
+                else:
+                    attr = attr[name]
             else:
                 attr = getattr(objclass,name)
         except (AttributeError, KeyError):


### PR DESCRIPTION
## Summary
As of python 3.15.0a1, the __dict__ and __weakref__ descriptors now use a single descriptor instance per interpreter, shared across all types that need them. Adjust _getattr to get the singletons.
