### PR TITLE
ensure valid class qualname in getsource

### DIFF
--- a/dill/source.py
+++ b/dill/source.py
@@ -388,6 +388,8 @@ def getsource(object, alias='', lstrip=False, enclosing=False, \
             # now we are dealing with an instance...
             name = object.__class__.__name__
             module = object.__module__
+            if not name.isidentifier() or not all(i.isidentifier() for i in module.split('.')): #XXX: does exclusing malicious code exclude valid use?
+                raise SyntaxError('invalid syntax')
             if module in ['builtins','__builtin__']:
                 return getimport(object, alias, builtin=builtin)
             else: #FIXME: leverage getimport? use 'from module import name'?

--- a/dill/tests/test_source.py
+++ b/dill/tests/test_source.py
@@ -161,6 +161,18 @@ def test_numpy():
 def test_foo():
   assert importable(_foo, source=True).startswith("import dill\nclass Foo(object):\n  def bar(self, x):\n    return x*x+x\ndill.loads(")
 
+def test_safe():
+  import abc
+  obj = abc.ABC()
+  obj.__class__.__name__ = "(abc' + print('foo')]) # "
+  try:
+    source = getsource(obj, force=True)
+    assert False
+  except TypeError:
+    assert False
+  except SyntaxError:
+    pass
+
 if __name__ == '__main__':
     test_getsource()
     test_itself()
@@ -171,3 +183,4 @@ if __name__ == '__main__':
     test_importable()
     test_numpy()
     test_foo()
+    test_safe()


### PR DESCRIPTION
## Summary
throw a SyntaxError for invalid class qualnames in dill.source.getsource

