### PR TITLE
avoid numpy segfault for 3.15.0a3

### DIFF
--- a/dill/tests/test_detect.py
+++ b/dill/tests/test_detect.py
@@ -138,6 +138,9 @@ def test_deleted():
 def test_lambdify():
     try:
         from sympy import symbols, lambdify
+        from numpy import __version__ as numversion
+        if numversion < '2.4.0' and sys.hexversion == 0x30f00a3:
+            return #NOTE: numpy Segfaults for the above combination
     except ImportError:
         return
     settings['recurse'] = True


### PR DESCRIPTION
## Summary
avoid numpy segfault for 3.15.0a3

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Artifacts produced with the main branch work as expected under this PR.
