### PR TITLE
fix pypy311 test_registered, update travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: jammy
+dist: noble
 language: python
 
 matrix:
@@ -6,13 +6,15 @@ matrix:
         - python: '3.9'
           dist: focal
           env:
+
+        - python: '3.10'
+          dist: jammy
+          env:
             - COVERAGE="true"
             - NUMPY="true"
 
-        - python: '3.10'
-          env:
-
         - python: '3.11'
+          dist: jammy
           env:
 
         - python: '3.12'
@@ -21,10 +23,10 @@ matrix:
         - python: '3.13'
           env:
 
-        - python: '3.14-dev'
+        - python: '3.14'
           env:
 
-        - python: '3.15-dev'
+        - python: '3.15t-dev'
           env:
 
         - python: 'pypy3.9-7.3.15' # at 7.3.16
@@ -37,8 +39,7 @@ matrix:
           env:
 
     allow_failures:
-        - python: '3.15-dev' # prerelease; CI missing
-        - python: 'pypy3.11-7.3.20' # CI missing
+        - python: '3.15t-dev' # prerelease
     fast_finish: true
 
 cache:

--- a/dill/_objects.py
+++ b/dill/_objects.py
@@ -176,7 +176,7 @@ a['OptionParserType'] = _oparser = optparse.OptionParser() # pickle ok
 a['OptionGroupType'] = optparse.OptionGroup(_oparser,"foo") # pickle ok
 a['OptionType'] = optparse.Option('--foo') # pickle ok
 if HAS_CTYPES:
-    z = x if IS_PYPY else a
+    z = x if (IS_PYPY and sys.hexversion < 0x30b0df0) else a
     z['CCharType'] = _cchar = ctypes.c_char()
     z['CWCharType'] = ctypes.c_wchar() # fail == 2.6
     z['CByteType'] = ctypes.c_byte()
@@ -218,7 +218,7 @@ a['BufferedIOBaseType'] = io.BufferedIOBase()
 a['UnicodeIOType'] = TextIO() # the new StringIO
 a['LoggerAdapterType'] = logging.LoggerAdapter(_logger,_dict) # pickle ok
 if HAS_CTYPES:
-    z = x if IS_PYPY else a
+    z = x if (IS_PYPY and sys.hexversion < 0x30b0df0) else a
     z['CBoolType'] = ctypes.c_bool(1)
     z['CLongDoubleType'] = ctypes.c_longdouble()
     del z
@@ -227,7 +227,7 @@ import argparse
 a['OrderedDictType'] = collections.OrderedDict(_dict)
 a['CounterType'] = collections.Counter(_dict)
 if HAS_CTYPES:
-    z = x if IS_PYPY else a
+    z = x if (IS_PYPY and sys.hexversion < 0x30b0df0) else a
     z['CSSizeTType'] = ctypes.c_ssize_t()
     del z
 # generic operating system services (CH 15)


### PR DESCRIPTION
## Summary
update `dill.objects` to reflect better pickling of ctypes types in pypy311
update travis to use 3.15t, 3.14, coverage with 3.10, dist of noble