### PR TITLE
Fix insecure default temp file path in session dump/load

### DIFF
--- a/dill/session.py
+++ b/dill/session.py
@@ -24,8 +24,52 @@ import tempfile
 
 TEMPDIR = pathlib.PurePath(tempfile.gettempdir())
 
+
+class SecurityWarning(UserWarning):
+    """Warning for insecure operations."""
+    pass
+
+
 # Type hints.
 from typing import Optional, Union
+
+
+def _check_symlink(path):
+    """Raise OSError if *path* is a symlink (TOCTOU-safe stat check)."""
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return
+    import stat
+    if stat.S_ISLNK(st.st_mode):
+        raise OSError("refusing to open symlink at %r" % path)
+
+
+def _safe_open_for_writing(path):
+    """Open *path* for writing with exclusive-create or symlink check.
+
+    If the file does not yet exist, create it with mode 0o600 using
+    ``O_CREAT | O_EXCL`` so that no other process can race us.  If the
+    file already exists, verify it is **not** a symlink before opening.
+    """
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        _check_symlink(path)
+        fd = os.open(path, os.O_WRONLY | os.O_TRUNC, 0o600)
+    return os.fdopen(fd, 'wb')
+
+
+def _warn_if_default_path(filename):
+    """Emit a SecurityWarning when using the shared default temp path."""
+    if filename is not None:
+        return
+    warnings.warn(
+        "Using default shared path %s is insecure. "
+        "Pass an explicit filename." % str(TEMPDIR / 'session.pkl'),
+        SecurityWarning,
+        stacklevel=3,
+    )
 
 from dill import _dill, Pickler, Unpickler
 from ._dill import (
@@ -240,9 +284,10 @@ def dump_module(
     if hasattr(filename, 'write'):
         file = filename
     else:
+        _warn_if_default_path(filename)
         if filename is None:
             filename = str(TEMPDIR/'session.pkl')
-        file = open(filename, 'wb')
+        file = _safe_open_for_writing(filename)
     try:
         pickler = Pickler(file, protocol, **kwds)
         pickler._original_main = main
@@ -439,8 +484,10 @@ def load_module(
     if hasattr(filename, 'read'):
         file = filename
     else:
+        _warn_if_default_path(filename)
         if filename is None:
             filename = str(TEMPDIR/'session.pkl')
+        _check_symlink(filename)
         file = open(filename, 'rb')
     try:
         file = _make_peekable(file)
@@ -572,8 +619,10 @@ def load_module_asdict(
     if hasattr(filename, 'read'):
         file = filename
     else:
+        _warn_if_default_path(filename)
         if filename is None:
             filename = str(TEMPDIR/'session.pkl')
+        _check_symlink(filename)
         file = open(filename, 'rb')
     try:
         file = _make_peekable(file)

--- a/dill/tests/test_session.py
+++ b/dill/tests/test_session.py
@@ -271,6 +271,56 @@ def test_load_module_asdict():
         assert 'y' not in main_vars
         assert 'empty' in main_vars
 
+def test_symlink_rejected(tmp_path=None):
+    """dump_module/load_module/load_module_asdict must reject symlinks (issue #749)"""
+    import tempfile, shutil
+    tmp_dir = tmp_path or tempfile.mkdtemp()
+    try:
+        real_file = os.path.join(tmp_dir, 'real.pkl')
+        link_file = os.path.join(tmp_dir, 'link.pkl')
+
+        # Create a real session file, then a symlink to it.
+        dill.dump_module(real_file)
+        os.symlink(real_file, link_file)
+
+        # load_module must refuse the symlink.
+        try:
+            dill.load_module(link_file)
+            assert False, "load_module should have raised OSError for symlink"
+        except OSError:
+            pass
+
+        # load_module_asdict must refuse the symlink.
+        try:
+            dill.load_module_asdict(link_file)
+            assert False, "load_module_asdict should have raised OSError for symlink"
+        except OSError:
+            pass
+
+        # dump_module must refuse to overwrite a symlink.
+        try:
+            dill.dump_module(link_file)
+            assert False, "dump_module should have raised OSError for symlink"
+        except OSError:
+            pass
+    finally:
+        if tmp_path is None:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+def test_default_path_warning():
+    """Using default path should emit SecurityWarning (issue #749)"""
+    from dill.session import SecurityWarning as _SecurityWarning
+    import warnings as _warnings
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        dill.dump_module()  # default path
+    security_warnings = [w for w in caught if issubclass(w.category, _SecurityWarning)]
+    assert len(security_warnings) >= 1, "expected SecurityWarning for default path"
+    # Clean up the default file.
+    from dill.session import TEMPDIR
+    with suppress(OSError):
+        os.remove(str(TEMPDIR / 'session.pkl'))
+
 if __name__ == '__main__':
     test_session_main(refimported=False)
     test_session_main(refimported=True)
@@ -278,3 +328,5 @@ if __name__ == '__main__':
     test_runtime_module()
     test_refimported_imported_as()
     test_load_module_asdict()
+    test_symlink_rejected()
+    test_default_path_warning()


### PR DESCRIPTION
## Summary

Fixes #749 — the default `/tmp/session.pkl` path used by `dump_module()`, `load_module()`, and `load_module_asdict()` is insecure because `/tmp` is world-writable and shared, making it vulnerable to symlink attacks and race conditions.

### Changes

- **Symlink rejection**: Added `_check_symlink()` that uses `os.lstat()` to reject symlinks before reading or writing session files.
- **Safe file creation**: Added `_safe_open_for_writing()` that uses `os.open()` with `O_CREAT | O_EXCL | O_WRONLY` and mode `0o600` for race-free exclusive file creation. If the file already exists, it verifies it is not a symlink before opening.
- **SecurityWarning**: Emits a `SecurityWarning` when the default shared `/tmp/session.pkl` path is used, advising users to pass an explicit filename.
- **Tests**: Added `test_symlink_rejected()` and `test_default_path_warning()` to `test_session.py`.

### Files changed

- `dill/session.py` — security helpers and warning in `dump_module`, `load_module`, `load_module_asdict`
- `dill/tests/test_session.py` — new security tests

## Test plan

- [x] Existing `test_session.py` tests pass
- [x] New `test_symlink_rejected` verifies symlinks are rejected by all three functions
- [x] New `test_default_path_warning` verifies SecurityWarning is emitted for the default path