### PR TITLE
Fix insecure default temp file path in session dump/load

### DIFF
--- a/dill/session.py
+++ b/dill/session.py
@@ -15,6 +15,10 @@ __all__ = [
     'dump_session', 'load_session' # backward compatibility
 ]
 
+class SecurityWarning(UserWarning):
+    """Warning for insecure default temp file paths."""
+    pass
+
 import re
 import os
 import sys
@@ -23,6 +27,7 @@ import pathlib
 import tempfile
 
 TEMPDIR = pathlib.PurePath(tempfile.gettempdir())
+SESSION_TEMPFILE = str(TEMPDIR/'session.pkl')
 
 # Type hints.
 from typing import Optional, Union
@@ -33,6 +38,42 @@ from ._dill import (
     _import_module, _is_builtin_module, _is_imported_module, _main_module,
     _reverse_typemap, __builtin__, UnpicklingError,
 )
+
+def _check_symlink(path):
+    """Raise OSError if *path* is a symlink."""
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return  # file does not exist yet – nothing to check
+    import stat
+    if stat.S_ISLNK(st.st_mode):
+        raise OSError("refusing to operate on symlink: %r" % path)
+
+def _safe_open_for_writing(path):
+    """Open *path* for exclusive creation with restricted permissions.
+
+    Uses ``O_CREAT | O_EXCL | O_WRONLY`` so the call is atomic – it will
+    fail if the file already exists rather than silently following a
+    symlink.  When the file *does* already exist, fall back to a regular
+    open after verifying that it is not a symlink.
+    """
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    try:
+        fd = os.open(path, flags, 0o600)
+    except FileExistsError:
+        _check_symlink(path)
+        fd = os.open(path, os.O_WRONLY | os.O_TRUNC, 0o600)
+    return os.fdopen(fd, 'wb')
+
+_DEFAULT_PATH_WARNING = (
+    "using the default session file %r which is in a world-writable "
+    "directory.  Pass an explicit filename to avoid a security risk."
+) % SESSION_TEMPFILE
+
+def _warn_if_default_path(filename):
+    """Emit a SecurityWarning when the caller relies on the default path."""
+    if filename is None:
+        warnings.warn(_DEFAULT_PATH_WARNING, SecurityWarning, stacklevel=3)
 
 def _module_map():
     """get map of imported modules"""
@@ -240,9 +281,10 @@ def dump_module(
     if hasattr(filename, 'write'):
         file = filename
     else:
+        _warn_if_default_path(filename)
         if filename is None:
-            filename = str(TEMPDIR/'session.pkl')
-        file = open(filename, 'wb')
+            filename = SESSION_TEMPFILE
+        file = _safe_open_for_writing(filename)
     try:
         pickler = Pickler(file, protocol, **kwds)
         pickler._original_main = main
@@ -439,8 +481,10 @@ def load_module(
     if hasattr(filename, 'read'):
         file = filename
     else:
+        _warn_if_default_path(filename)
         if filename is None:
-            filename = str(TEMPDIR/'session.pkl')
+            filename = SESSION_TEMPFILE
+        _check_symlink(filename)
         file = open(filename, 'rb')
     try:
         file = _make_peekable(file)
@@ -572,8 +616,10 @@ def load_module_asdict(
     if hasattr(filename, 'read'):
         file = filename
     else:
+        _warn_if_default_path(filename)
         if filename is None:
-            filename = str(TEMPDIR/'session.pkl')
+            filename = SESSION_TEMPFILE
+        _check_symlink(filename)
         file = open(filename, 'rb')
     try:
         file = _make_peekable(file)

--- a/dill/tests/test_session.py
+++ b/dill/tests/test_session.py
@@ -271,6 +271,70 @@ def test_load_module_asdict():
         assert 'y' not in main_vars
         assert 'empty' in main_vars
 
+def test_symlink_rejected():
+    """symlinks must be rejected by dump_module, load_module, load_module_asdict"""
+    import tempfile, warnings
+    tmpdir = tempfile.mkdtemp()
+    real_file = os.path.join(tmpdir, 'real.pkl')
+    link_file = os.path.join(tmpdir, 'link.pkl')
+
+    # Create a real file and a symlink pointing to it.
+    with open(real_file, 'wb') as f:
+        f.write(b'')
+    os.symlink(real_file, link_file)
+
+    try:
+        # dump_module must refuse to write through a symlink.
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                dill.dump_module(link_file)
+            raise AssertionError("dump_module should have raised OSError for symlink")
+        except OSError:
+            pass
+
+        # Dump a valid session to the real file so load tests have something to read.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            dill.dump_module(real_file)
+
+        # load_module must refuse to read through a symlink.
+        try:
+            dill.load_module(link_file)
+            raise AssertionError("load_module should have raised OSError for symlink")
+        except OSError:
+            pass
+
+        # load_module_asdict must refuse to read through a symlink.
+        try:
+            dill.load_module_asdict(link_file)
+            raise AssertionError("load_module_asdict should have raised OSError for symlink")
+        except OSError:
+            pass
+    finally:
+        with suppress(OSError):
+            os.remove(link_file)
+        with suppress(OSError):
+            os.remove(real_file)
+        with suppress(OSError):
+            os.rmdir(tmpdir)
+
+def test_default_path_warning():
+    """a SecurityWarning must be emitted when the default path is used"""
+    import warnings
+    from dill.session import SecurityWarning
+    for func in (dill.dump_module, dill.load_module, dill.load_module_asdict):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            try:
+                func()  # uses the default path
+            except Exception:
+                pass  # we only care about the warning, not success
+            security_warnings = [x for x in w if issubclass(x.category, SecurityWarning)]
+            assert security_warnings, (
+                "%s() did not emit SecurityWarning for the default path" % func.__name__
+            )
+
 if __name__ == '__main__':
     test_session_main(refimported=False)
     test_session_main(refimported=True)
@@ -278,3 +342,5 @@ if __name__ == '__main__':
     test_runtime_module()
     test_refimported_imported_as()
     test_load_module_asdict()
+    test_symlink_rejected()
+    test_default_path_warning()


### PR DESCRIPTION
## Summary

Fixes #749 — the default `/tmp/session.pkl` path used by `dump_module()`, `load_module()`, and `load_module_asdict()` is insecure because `/tmp` is world-writable and shared, making it vulnerable to symlink attacks and race conditions.

### Changes

- **Symlink rejection**: Added `_check_symlink()` that uses `os.lstat()` to reject symlinks before reading or writing session files.
- **Safe file creation**: Added `_safe_open_for_writing()` that uses `os.open()` with `O_CREAT | O_EXCL | O_WRONLY` and mode `0o600` for race-free exclusive file creation. If the file already exists, it verifies it is not a symlink before opening.
- **SecurityWarning**: Emits a `SecurityWarning` when the default shared `/tmp/session.pkl` path is used, advising users to pass an explicit filename.
- **Tests**: Added `test_symlink_rejected()` and `test_default_path_warning()` to `test_session.py`.

### Files changed

- `dill/session.py` — security helpers and warning in `dump_module`, `load_module`, `load_module_asdict`
- `dill/tests/test_session.py` — new security tests

## Test plan

- [x] Existing `dump_module`/`load_module`/`load_module_asdict` behavior unchanged for explicit paths and stream objects
- [x] New `test_symlink_rejected` verifies symlinks are rejected by all three functions
- [x] New `test_default_path_warning` verifies `SecurityWarning` is emitted for the default path