### PR TITLE
open session files with O_NOFOLLOW to close symlink toctou

### DIFF
--- a/dill/session.py
+++ b/dill/session.py
@@ -39,6 +39,9 @@ from ._dill import (
     _reverse_typemap, __builtin__, UnpicklingError,
 )
 
+# O_NOFOLLOW is POSIX-only; degrade to a no-op flag elsewhere (e.g. Windows).
+_O_NOFOLLOW = getattr(os, 'O_NOFOLLOW', 0)
+
 def _check_symlink(path):
     """Raise OSError if *path* is a symlink."""
     try:
@@ -54,16 +57,27 @@ def _safe_open_for_writing(path):
 
     Uses ``O_CREAT | O_EXCL | O_WRONLY`` so the call is atomic – it will
     fail if the file already exists rather than silently following a
-    symlink.  When the file *does* already exist, fall back to a regular
-    open after verifying that it is not a symlink.
+    symlink.  When the file *does* already exist, fall back to a truncating
+    open that carries ``O_NOFOLLOW`` so the kernel itself refuses a symlink
+    in a single syscall, leaving no window between the check and the open.
     """
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _O_NOFOLLOW
     try:
         fd = os.open(path, flags, 0o600)
     except FileExistsError:
         _check_symlink(path)
-        fd = os.open(path, os.O_WRONLY | os.O_TRUNC, 0o600)
+        fd = os.open(path, os.O_WRONLY | os.O_TRUNC | _O_NOFOLLOW, 0o600)
     return os.fdopen(fd, 'wb')
+
+def _safe_open_for_reading(path):
+    """Open *path* read-only, refusing to follow a final symlink.
+
+    ``O_NOFOLLOW`` makes the symlink rejection part of the open syscall so
+    there is no time-of-check/time-of-use gap with the preceding lstat.
+    """
+    _check_symlink(path)
+    fd = os.open(path, os.O_RDONLY | _O_NOFOLLOW)
+    return os.fdopen(fd, 'rb')
 
 _DEFAULT_PATH_WARNING = (
     "using the default session file %r which is in a world-writable "
@@ -484,8 +498,7 @@ def load_module(
         _warn_if_default_path(filename)
         if filename is None:
             filename = SESSION_TEMPFILE
-        _check_symlink(filename)
-        file = open(filename, 'rb')
+        file = _safe_open_for_reading(filename)
     try:
         file = _make_peekable(file)
         #FIXME: dill.settings are disabled
@@ -619,8 +632,7 @@ def load_module_asdict(
         _warn_if_default_path(filename)
         if filename is None:
             filename = SESSION_TEMPFILE
-        _check_symlink(filename)
-        file = open(filename, 'rb')
+        file = _safe_open_for_reading(filename)
     try:
         file = _make_peekable(file)
         main_name = _identify_module(file)

--- a/dill/session.py
+++ b/dill/session.py
@@ -39,7 +39,9 @@ from ._dill import (
     _reverse_typemap, __builtin__, UnpicklingError,
 )
 
-# O_NOFOLLOW is POSIX-only; degrade to a no-op flag elsewhere (e.g. Windows).
+# O_NOFOLLOW is POSIX-only; elsewhere (e.g. Windows) fall back to 0, the
+# bitwise-OR identity, so the flag drops out.  Each os.open below sets its
+# own access mode, so 0 -- not O_RDONLY -- is the correct neutral value.
 _O_NOFOLLOW = getattr(os, 'O_NOFOLLOW', 0)
 
 def _check_symlink(path):

--- a/dill/tests/test_session.py
+++ b/dill/tests/test_session.py
@@ -335,6 +335,51 @@ def test_default_path_warning():
                 "%s() did not emit SecurityWarning for the default path" % func.__name__
             )
 
+def test_symlink_toctou():
+    """a symlink swapped in after the lstat check must still be refused"""
+    if not hasattr(os, 'O_NOFOLLOW'):
+        return  # platform without symlink-safe open semantics
+    import stat, tempfile, warnings
+    from dill import session as _session
+    tmpdir = tempfile.mkdtemp()
+    target = os.path.join(tmpdir, 'secret')
+    session_path = os.path.join(tmpdir, 'session.pkl')
+    with open(target, 'w') as f:
+        f.write('secret')
+    with open(session_path, 'wb') as f:
+        f.write(b'benign')
+
+    # Simulate an attacker that wins the race in the window between the
+    # symlink check and the open by swapping the file for a symlink at the
+    # instant lstat() confirms it is a regular file.
+    orig_lstat = os.lstat
+    swapped = []
+    def racing_lstat(path, *a, **k):
+        st = orig_lstat(path, *a, **k)
+        if not swapped and str(path) == session_path and not stat.S_ISLNK(st.st_mode):
+            os.remove(session_path)
+            os.symlink(target, session_path)
+            swapped.append(True)
+        return st
+
+    _session.os.lstat = racing_lstat
+    try:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                dill.load_module(session_path)
+            raise AssertionError("read followed a symlink swapped in at the TOCTOU window")
+        except OSError:
+            pass
+    finally:
+        _session.os.lstat = orig_lstat
+        with suppress(OSError):
+            os.remove(session_path)
+        with suppress(OSError):
+            os.remove(target)
+        with suppress(OSError):
+            os.rmdir(tmpdir)
+
 if __name__ == '__main__':
     test_session_main(refimported=False)
     test_session_main(refimported=True)
@@ -344,3 +389,4 @@ if __name__ == '__main__':
     test_load_module_asdict()
     test_symlink_rejected()
     test_default_path_warning()
+    test_symlink_toctou()


### PR DESCRIPTION
Repro: in a world-writable dir, plant a regular `session.pkl`, then race a symlink to a victim file into place in the window between `_check_symlink()`s `lstat` and the following `open()`; `load_module`/`load_module_asdict` read through the link and the `dump_module` truncating fallback writes through it.
Cause: the symlink guard and the open are two separate syscalls, so the `lstat` result is stale by the time the path is opened (a classic TOCTOU).
Fix: open with `O_NOFOLLOW` so the kernel refuses a final symlink as part of the open itself; `_check_symlink` stays as an early, friendly error. `O_NOFOLLOW` is gated through `getattr(os, ...)` so non-POSIX platforms degrade to the prior behaviour.

The added `test_symlink_toctou` swaps the file for a symlink exactly at the `lstat` instant: it follows the link (and trips on the foreign contents) before this change and raises `OSError` after.