### PR TITLE
restrict permissions of recreated file in _create_filehandle

### DIFF
--- a/dill/_dill.py
+++ b/dill/_dill.py
@@ -880,7 +880,7 @@ def _create_filehandle(name, mode, position, closed, open, strictio, fmode, fdat
                     flags |= os.O_RDWR
                 else:
                     flags |= os.O_WRONLY
-                f = os.fdopen(os.open(name, flags), mode)
+                f = os.fdopen(os.open(name, flags, 0o600), mode)
                 # set name to the correct value
                 r = getattr(f, "buffer", f)
                 r = getattr(r, "raw", r)

--- a/dill/tests/test_file.py
+++ b/dill/tests/test_file.py
@@ -489,6 +489,30 @@ def test_nostrictio_contentsfmode():
     teardown_module()
 
 
+def test_recreated_file_permissions():
+    # a file recreated from a pickled handle must not be group/other
+    # accessible or executable
+    import platform
+    if os.name != 'posix' or platform.python_implementation() == 'PyPy':
+        return
+    pname = "_test_perms.txt"
+    old_umask = os.umask(0o022)  # a permissive umask exposes the missing mode
+    try:
+        f = open(pname, "w")
+        f.write("secret")
+        dumped = dill.dumps(f, fmode=dill.CONTENTS_FMODE)
+        f.close()
+        os.remove(pname)  # force recreation on load (the file-transfer case)
+        f2 = dill.loads(dumped)
+        f2.close()
+        bits = os.stat(pname).st_mode & 0o777
+        assert bits & 0o177 == 0, "recreated file is world-accessible: %o" % bits
+    finally:
+        os.umask(old_umask)
+        if os.path.exists(pname):
+            os.remove(pname)
+
+
 #bench(True, dill.HANDLE_FMODE, False)
 #bench(True, dill.FILE_FMODE, False)
 #bench(True, dill.CONTENTS_FMODE, True)
@@ -498,3 +522,4 @@ if __name__ == '__main__':
     test_nostrictio_handlefmode()
     test_nostrictio_filefmode()
     test_nostrictio_contentsfmode()
+    test_recreated_file_permissions()


### PR DESCRIPTION
Repro: pickle a private (`0o600`) file handle with `fmode=dill.CONTENTS_FMODE`, then `dill.loads` it on a host where the file is absent (the documented file-transfer case).
Cause: `_create_filehandle` calls `os.open(name, flags)` with no mode, so the recreated file is created from the `0o777` base and lands at `0o755` under a typical umask, i.e. world-readable and executable.
Fix: pass `0o600` to `os.open` so the recreated file is owner-only, matching the mode already used for session files.