### PR TITLE
ensure valid names before the verification exec in _getimport

### DIFF
--- a/dill/source.py
+++ b/dill/source.py
@@ -710,6 +710,9 @@ def _getimport(head, tail, alias='', verify=True, builtin=False):
     #        (could fix in 'namespace' to check obj for closure)
     if verify and not head.startswith('dill.'):# weird behavior for dill
        #print(_str)
+        if not all(i.isidentifier() for i in tail.split('.')) \
+           or (head and not all(i.isidentifier() for i in head.split('.'))): #XXX: as in getsource
+            raise SyntaxError('invalid syntax')
         try: exec(_str) #XXX: check if == obj? (name collision)
         except ImportError: #XXX: better top-down or bottom-up recursion?
             _head = head.rsplit(".",1)[0] #(or get all, then compare == obj?)

--- a/dill/tests/test_source.py
+++ b/dill/tests/test_source.py
@@ -173,6 +173,18 @@ def test_safe():
   except SyntaxError:
     pass
 
+def test_safe_import():
+  import dill
+  def obj(): pass
+  obj.__module__ = 'os'
+  obj.__name__ = "path\nimport dill; dill._injected = True\n#"
+  try:
+    source = getimport(obj)
+    assert False
+  except SyntaxError:
+    pass
+  assert not hasattr(dill, '_injected')
+
 if __name__ == '__main__':
     test_getsource()
     test_itself()
@@ -184,3 +196,4 @@ if __name__ == '__main__':
     test_numpy()
     test_foo()
     test_safe()
+    test_safe_import()


### PR DESCRIPTION
Repro: `obj.__module__ = 'os'; obj.__name__ = "path\nimport dill; dill._injected = True\n#"`, then `getimport(obj)` runs the injected line; `importable`, `getimportable` and `likely_import` reach the same spot.
Cause: `_getimport` interpolates `head`/`tail` into `from head import tail` and `exec`s it to verify the import, so a `__name__` carrying a newline is executed instead of rejected.
Fix: require both to be dotted identifiers before that `exec` and raise `SyntaxError`, as `getsource` already does for a bad qualname in d948ecd. `verify=False` never execs, so that path is untouched.