### PR TITLE
escape names interpolated into source-matching patterns

### DIFF
--- a/dill/source.py
+++ b/dill/source.py
@@ -235,7 +235,9 @@ def findsource(object):
     except AttributeError: pass
     if isclass(object):
         name = object.__name__
-        pat = re.compile(r'^(\s*)class\s*' + name + r'\b')
+        # __name__ is not required to be an identifier, so escape it to keep
+        # it a literal rather than letting it act as part of the pattern
+        pat = re.compile(r'^(\s*)class\s*' + re.escape(name) + r'\b')
         # make some effort to find the best matching class definition:
         # use the one with the least indentation, which is the one
         # that's most probably not inside a function definition.
@@ -853,7 +855,7 @@ def _closuredimport(func, alias='', builtin=False):
         else: # we have to "hack" a bit... and maybe be lucky
             encl = outermost(func)
             # pattern: 'func = enclosing(fobj'
-            pat = r'.*[\w\s]=\s*'+getname(encl)+r'\('+getname(fobj)
+            pat = r'.*[\w\s]=\s*'+re.escape(getname(encl))+r'\('+re.escape(getname(fobj))
             mod = getname(getmodule(encl))
             #HACK: get file containing 'outer' function; is func there?
             lines,_ = findsource(encl)
@@ -880,7 +882,7 @@ def _closuredimport(func, alias='', builtin=False):
             lines,_ = findsource(name)
             # pattern: 'func = enclosing('
             candidate = [line for line in lines if getname(name) in line and \
-                         re.match(r'.*[\w\s]=\s*'+getname(name)+r'\(', line)]
+                         re.match(r'.*[\w\s]=\s*'+re.escape(getname(name))+r'\(', line)]
             if not len(candidate): raise TypeError('import could not be found')
             candidate = candidate[-1]
             name = candidate.split('=',1)[0].split()[-1].strip()

--- a/dill/tests/test_source.py
+++ b/dill/tests/test_source.py
@@ -28,6 +28,12 @@ _foo = Foo()
 def add(x,y):
   return x+y
 
+def _enclose(f):
+  def _wrapper(x,y):
+    return f(x,y)
+  return _wrapper
+closured = _enclose(add)
+
 # yes, same as 'f', but things are tricky when it comes to pointers
 squared = lambda x:x**2
 
@@ -128,6 +134,12 @@ def test_importable():
   assert importable(100, builtin=True, source=False) == '100\n'
 
 
+def test_closured_import():
+  # closured functions take the pattern-matching path, where the enclosing
+  # and inner function names are matched literally against the source
+  assert importable(closured, source=False) == 'from %s import closured\n' % __name__
+
+
 def test_numpy():
   try:
     import numpy as np
@@ -207,6 +219,7 @@ if __name__ == '__main__':
     test_dynamic()
     test_classes()
     test_importable()
+    test_closured_import()
     test_numpy()
     test_foo()
     test_safe()

--- a/dill/tests/test_source.py
+++ b/dill/tests/test_source.py
@@ -173,6 +173,32 @@ def test_safe():
   except SyntaxError:
     pass
 
+class Baz:
+  pass
+
+class Qux: # sits after Baz, so a pattern-like name resolves here instead
+  pass
+
+def test_name_not_a_pattern():
+  # __name__ is assignable and need not be an identifier, so it has to be
+  # matched literally rather than as part of the class-definition pattern
+  name = Baz.__name__
+  try:
+    Baz.__name__ = r'\w+' # otherwise matches the definition of Qux
+    try:
+      source = getsource(Baz)
+      assert False, source
+    except IOError:
+      pass
+    Baz.__name__ = 'Baz((' # otherwise fails to compile
+    try:
+      getsource(Baz)
+      assert False
+    except IOError:
+      pass
+  finally:
+    Baz.__name__ = name
+
 if __name__ == '__main__':
     test_getsource()
     test_itself()
@@ -184,3 +210,4 @@ if __name__ == '__main__':
     test_numpy()
     test_foo()
     test_safe()
+    test_name_not_a_pattern()


### PR DESCRIPTION
Repro: set `Baz.__name__ = r'\w+'` on any class and call `dill.source.getsource(Baz)`. It returns the source of a different class defined later in the same file. With `Baz.__name__ = 'Baz(('` it raises `re.error` rather than the `IOError` the function documents.

Cause: `findsource` concatenates `__name__` straight into the class-definition pattern, so a name that is not an identifier is matched as a pattern instead of literally. `__name__` is freely assignable and is not required to be an identifier. `_closuredimport` builds its two candidate patterns from `getname()` the same way, and `getname()` can return a `repr` containing brackets even for ordinary objects.

Fix: `re.escape` the interpolated names at the three sites. `re.escape` leaves identifiers untouched, so behaviour for ordinary names is unchanged. Test added covers both the wrong-match and the uncompilable name.