### PR TITLE
create trace redirect file with restricted permissions

### DIFF
--- a/dill/logger.py
+++ b/dill/logger.py
@@ -257,6 +257,19 @@ def trace(arg: Union[bool, TextIO, str, os.PathLike] = None, *, mode: str = 'a')
         return TraceManager(file=arg, mode=mode)
     logger.setLevel(logging.INFO if arg else logging.WARNING)
 
+def _restrict_new_logfile(file):
+    # logging.FileHandler creates the log at the process umask (world-readable
+    # by default), but a redirected trace embeds object reprs and whatever the
+    # yielded log() function writes.  Pre-create a *new* target owner-only so
+    # the handler inherits 0o600; leave an existing file's permissions alone.
+    if os.name != 'posix':
+        return
+    try:
+        fd = os.open(os.fspath(file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except (FileExistsError, OSError):
+        return
+    os.close(fd)
+
 class TraceManager(contextlib.AbstractContextManager):
     """context manager version of trace(); can redirect the trace to a file"""
     def __init__(self, file, mode):
@@ -270,6 +283,7 @@ class TraceManager(contextlib.AbstractContextManager):
             if self.file_is_stream:
                 self.handler = logging.StreamHandler(self.file)
             else:
+                _restrict_new_logfile(self.file)
                 self.handler = logging.FileHandler(self.file, self.mode)
             adapter.removeHandler(stderr_handler)
             adapter.addHandler(self.handler)

--- a/dill/tests/test_logger.py
+++ b/dill/tests/test_logger.py
@@ -53,6 +53,27 @@ def test_trace_to_file(stream_trace):
     file_trace, stream_trace = regdict.sub(r'\1{}>', file_trace), regdict.sub(r'\1{}>', stream_trace)
     assert file_trace == stream_trace
 
+def test_trace_file_permissions():
+    # a trace redirected to a new file must not be group/other accessible;
+    # it can contain object reprs and whatever log() writes
+    import os, platform
+    if os.name != 'posix' or platform.python_implementation() == 'PyPy':
+        return
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, 'trace.log')
+    old_umask = os.umask(0o022)  # a permissive umask exposes a missing mode
+    try:
+        with detect.trace(path) as log:
+            log("secret = %r", {'token': 's3cr3t'})
+            dill.dumps(test_obj)
+        bits = os.stat(path).st_mode & 0o777
+        assert bits & 0o077 == 0, "trace file is group/other accessible: %o" % bits
+    finally:
+        os.umask(old_umask)
+        if os.path.exists(path):
+            os.remove(path)
+        os.rmdir(d)
+
 if __name__ == '__main__':
     logger.removeHandler(stderr_handler)
     test_logging(should_trace=False)
@@ -68,3 +89,4 @@ if __name__ == '__main__':
     test_logging(should_trace=False)
     assert logger.getEffectiveLevel() == loglevel
     test_trace_to_file(stream_trace)
+    test_trace_file_permissions()


### PR DESCRIPTION
Repro: under umask `022`, redirect a pickling trace to a new path and inspect it:

    with dill.detect.trace('/tmp/dill.log') as log:
        log('secret = %r', {'token': 's3cr3t'})
        dill.dumps(obj)

Expected: the trace file is owner-only (`0o600`).
Actual: it is created `0o644`, world-readable, and it holds the logged object `repr`s.
Cause: `TraceManager.__enter__` opens the target with `logging.FileHandler`, which creates it at the process umask; `trace()` exposes `mode` but no way to set the file permissions, so on a shared host other local users can read the redirected trace.
Fix: pre-create a new target with `os.open(path, O_CREAT|O_EXCL|O_WRONLY, 0o600)` so the handler inherits `0o600`. An existing file keeps its own permissions and stream redirects are unchanged.
